### PR TITLE
New Image Dialog - clarify that the admin is able to view images

### DIFF
--- a/frontend/src/components/NewImageDialog.vue
+++ b/frontend/src/components/NewImageDialog.vue
@@ -94,7 +94,7 @@
             <v-checkbox
               v-model="isPrivate"
               density="comfortable"
-              label="Private Image (Private images won't show up in the public gallery)"
+              label="Private Image (Private images won't show up in the public gallery, but are visible to the admin for moderation purposes)"
             />
           </div>
 


### PR DESCRIPTION
Since the checkbox labels the image as "Private," the user may naturally expect that it will remain entirely private and inaccessible to others.

This clarification is meant to ensure the user understands that the page administrator can — and routinely does — view the image alongside the associated username. This way, the user has a clear understanding of what "Private" really means in this context. :)