### PR TITLE
feature/add message in frontend when image upload fails

### DIFF
--- a/frontend/src/_api/pub.ts
+++ b/frontend/src/_api/pub.ts
@@ -1,6 +1,6 @@
 import { GameId, GameSettings, ImageId, ImagesRequestData, NewGameDataRequestData } from '../../../common/src/Types'
 import Util from '../../../common/src/Util'
-import xhr, { JSON_HEADERS, XhrRequest } from './xhr'
+import xhr, { JSON_HEADERS, Response, XhrRequest } from './xhr'
 
 const auth = async (email: string, password: string) => {
   return await xhr.post('/api/auth/local', {
@@ -131,7 +131,7 @@ const upload = (
     isNsfw: boolean
     onProgress: (progress: number) => void
   },
-) => {
+): Promise<Response> => {
   const formData = new FormData()
   formData.append('file', data.file, data.file.name)
   formData.append('title', data.title)

--- a/frontend/src/views/NewGame.vue
+++ b/frontend/src/views/NewGame.vue
@@ -253,22 +253,34 @@ const onImageReportClicked = (newImage: ImageInfo) => {
   openDialog('report-image')
 }
 
-const uploadImage = async (data: any) => {
+const uploadImage = async (data: any): Promise<{ error: string } | { imageInfo: ImageInfo }> => {
   uploadProgress.value = 0
-  const res = await api.pub.upload({
-    file: data.file,
-    title: data.title,
-    copyrightName: data.copyrightName,
-    copyrightURL: data.copyrightURL,
-    tags: data.tags,
-    isPrivate: data.isPrivate,
-    isNsfw: data.isNsfw,
-    onProgress: (progress: number): void => {
-      uploadProgress.value = progress
-    },
-  })
-  uploadProgress.value = 1
-  return await res.json()
+  try {
+    const res = await api.pub.upload({
+      file: data.file,
+      title: data.title,
+      copyrightName: data.copyrightName,
+      copyrightURL: data.copyrightURL,
+      tags: data.tags,
+      isPrivate: data.isPrivate,
+      isNsfw: data.isNsfw,
+      onProgress: (progress: number): void => {
+        uploadProgress.value = progress
+      },
+    })
+    if (res.status === 413) {
+      throw 'The image you tried to upload is too large. Max file size is 20MB.'
+    }
+    const imageInfo = await res.json()
+    if (!imageInfo) {
+      throw 'The image upload failed for unknown reasons.'
+    }
+    uploadProgress.value = 1
+    return { imageInfo }
+  } catch (e) {
+    uploadProgress.value = 0
+    return { error: String(e) }
+  }
 }
 
 const onSaveImageClick = async (data: any) => {
@@ -287,18 +299,30 @@ const onSaveImageClick = async (data: any) => {
 
 const postToGalleryClick = async (data: any) => {
   uploading.value = 'postToGallery'
-  await uploadImage(data)
+  const result = await uploadImage(data)
   uploading.value = ''
+
+  if ('error' in result) {
+    toast(result.error, 'error')
+    return
+  }
+
   closeDialog()
   await loadImages()
 }
 
 const setupGameClick = async (data: any) => {
   uploading.value = 'setupGame'
-  const uploadedImage = await uploadImage(data)
+  const result = await uploadImage(data)
   uploading.value = ''
+
+  if ('error' in result) {
+    toast(result.error, 'error')
+    return
+  }
+
   void loadImages() // load images in background
-  image.value = uploadedImage
+  image.value = result.imageInfo
   openDialog('new-game')
 }
 

--- a/frontend/src/views/NewGame.vue
+++ b/frontend/src/views/NewGame.vue
@@ -268,13 +268,32 @@ const uploadImage = async (data: any): Promise<{ error: string } | { imageInfo: 
         uploadProgress.value = progress
       },
     })
+
+    // ⡀⡀⡀⡀⡀⡀⡀⣠⣴⣶⣶⣶⣶⣤⡀⡀⡀⡀⡀⡀⡀⡀
+    // ⡀⡀⡀⡀⡀⣤⣿⣿⣿⣿⣿⣿⣿⣿⣿⣦⡀⡀⡀⡀⡀⡀
+    // ⡀⡀⡀⡀⣼⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⢧⡀⡀⡀⡀⡀
+    // ⡀⡀⡀⢠⣿⣿⣿⢻⢸⣿⣿⠇⢿⣿⣿⣿⣿⡀⡀⡀⡀⡀
+    // ⡀⡀⡈⣾⣿⣿⡟⣘ ⠹⢿   ⣎⢿⣿⣿⡇⡀⡀⡀⡀
+    // ⡀⡀⡀⡇⣿⣿⠏⣾⡧    ⣿⡆⠇⣿⣿⡇⡀⡀⡀⡀
+    // ⡀⡀⡀⠁⣿⣿⡀          ⢼⣿⣼⡇⡀⡀⡀⡀
+    // ⡀⡀⡀⢠⣿⣿⣧⡀  ⡠⢄   ⣾⣿⣿⡻⡀⡀⡀⡀
+    // ⡀⡀⡀⠁⣿⣿⣿⣿⡦⣀⡀⡠⢶⣿⣿⣿⣿⣇⢂⡀⡀⡀
+    // ⡀⡀⠆⣼⣿⣿⣿⣿⡀⢄⢀⠔⡀⣿⣿⣿⣿⡟⡀⡀⡀⡀
+    // ⡀⡀⣿⣿⣿⣿⣿⣿⣿⣿⢿⣿⣿⣿⣿⣿⣿⣿⣿⡀⡀⡀
+    // ⡀⢰⡏⠉⠉⠉⠉⠉⠉⠉⠁⠉⠉⠉⠉⠉⠉⠉⠉⣿⡀⡀
+    // ⡀ ⣼⡇ 413 Request Entity  ⣿⡀⡀
+    // ⢀ ⠟⠃⡀    Too Large     ⣿⡇⡀⡀
+    // ⡀⡀⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠇⡀⡀⡀
+    // Comment requested during nC_para_ stream :)
     if (res.status === 413) {
       throw 'The image you tried to upload is too large. Max file size is 20MB.'
     }
+
     const imageInfo = await res.json()
     if (!imageInfo) {
       throw 'The image upload failed for unknown reasons.'
     }
+
     uploadProgress.value = 1
     return { imageInfo }
   } catch (e) {


### PR DESCRIPTION
- **show a message to the user when image upload failed**
- **add ascii/braille art comment**

[Ticket](https://jigsaw.hyottoko.club/feedback/bug-reports/p/stuck-after-uploading-cant-create-puzzle)
