### PR TITLE
Add nsfw settings, make queries nsfw-aware again and allow public nsfw uploads.

### DIFF
--- a/common/src/Types.ts
+++ b/common/src/Types.ts
@@ -644,6 +644,15 @@ export interface Leaderboard {
   userEntry: LeaderboardEntry | null
 }
 
+export interface LeaderboardEntryTmp {
+  leaderboard_id: LeaderboardId
+  rank: number
+  user_id: UserId
+  user_name: string
+  games_count: number
+  pieces_count: number
+  avatar_filename: string | null
+}
 export interface LeaderboardEntry {
   leaderboard_id: LeaderboardId
   rank: number
@@ -651,6 +660,7 @@ export interface LeaderboardEntry {
   user_name: string
   games_count: number
   pieces_count: number
+  avatar_url: string | null
 }
 
 export interface TwitchLivestream {
@@ -752,7 +762,7 @@ export interface ReplayHud extends Hud {
   setReplayFinished: () => void
 }
 
-export interface User {
+export interface Me {
   id: UserId
   name: string
   created: JSONDateString
@@ -760,6 +770,8 @@ export interface User {
   type: 'guest' | 'user'
   cannyToken: string | null
   groups: string[]
+  avatar: UserAvatar | null
+  nsfwUnblurred: boolean
 }
 
 export enum ImageSearchSort {
@@ -971,14 +983,18 @@ export interface UserAvatarRow {
 export interface UserSettingsRow {
   user_id: UserId
   avatar_id: UserAvatarId | null
+  nsfw_active: boolean
+  nsfw_unblurred: boolean
 }
 
 export interface UserSettings {
   userId: UserId
   avatarId: UserAvatarId | null
+  nsfwActive: boolean
+  nsfwUnblurred: boolean
 }
 
-export type CompleteUserProfile = {
+export type CompletePublicUserProfile = {
   user: {
     id: UserId
     username: string
@@ -994,4 +1010,12 @@ export type CompleteUserProfile = {
   isLiveOnTwitch: boolean
   images: ImageInfo[]
   games: GameInfo[]
+}
+
+export interface CompleteUserSettings {
+  userId: UserId
+  avatarId: UserAvatarId | null
+  avatar: UserAvatar | null
+  nsfwActive: boolean
+  nsfwUnblurred: boolean
 }

--- a/common/src/TypesApi.ts
+++ b/common/src/TypesApi.ts
@@ -1,4 +1,4 @@
-import type { Announcement, CompleteUserProfile, FeaturedRowWithCollections, GameId, GameInfo, GameSettings, ImageId, ImageInfo, Leaderboard, LivestreamsRow, Pagination, ReplayGameData, Tag, User, UserAvatarId, UserId } from './Types'
+import type { Announcement, CompletePublicUserProfile, CompleteUserSettings, FeaturedRowWithCollections, GameId, GameInfo, GameSettings, ImageId, ImageInfo, Leaderboard, LivestreamsRow, Pagination, ReplayGameData, Tag, Me, UserAvatarId, UserId } from './Types'
 
 export type * as Admin from './TypesAdminApi'
 
@@ -55,7 +55,7 @@ export type DeleteAvatarRequestData = {
 }
 
 export type MeResponseData = {
-  user: User
+  user: Me
   serverTimestamp: number
 } | {
   reason: string
@@ -150,7 +150,22 @@ export type UserProfileRequestData = {
 }
 
 export type UserProfileResponseData = {
-  userProfile: CompleteUserProfile
+  userProfile: CompletePublicUserProfile
+} | {
+  reason: string
+}
+
+export type GetUserSettingsRequestData = {
+  id: UserId
+}
+
+export type UpdateUserSettingsRequestData = {
+  nsfwActive: boolean
+  nsfwUnblurred: boolean
+}
+
+export type UserSettingsResponseData = {
+  userSettings: CompleteUserSettings
 } | {
   reason: string
 }

--- a/db/dbpatches/25_user_settings_nsfw.sql
+++ b/db/dbpatches/25_user_settings_nsfw.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.user_settings ADD nsfw_active bool DEFAULT false NOT NULL;
+ALTER TABLE public.user_settings ADD nsfw_unblurred bool DEFAULT false NOT NULL;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build:copyassets": "cpx \"src/assets/textures/*.{png,jpg,jpeg,svg,webp,mp3}\" ../build/public/assets/textures && cpx \"src/assets/featured-artist/*.{png,jpg,jpeg,svg,webp,mp3}\" ../build/public/assets/featured-artist && cpx \"src/assets/favicon/*.{png,jpg,jpeg,svg,webp,mp3}\" ../build/public/assets/favicon",
     "build": "vite build --config vite.config.build.mts && npm run build:copyassets",
-    "start": "vite",
+    "start": "vite --open",
     "lint": "tsc --noEmit && eslint src && stylelint \"src/**/*.scss\"",
     "test": ""
   },

--- a/frontend/src/_api/pub.ts
+++ b/frontend/src/_api/pub.ts
@@ -46,7 +46,7 @@ const changePassword = (
 const logout = (
   // no args
 ): Promise<Response<Api.LogoutResponseData>> => {
-  return xhr.post('/api/logout', {
+  return xhr.post('/api/user/logout', {
     headers: JSON_HEADERS,
   })
 }
@@ -142,6 +142,21 @@ const getUserProfileData = (
   return xhr.get(`/api/user-profile/${data.id}`)
 }
 
+const getUserSettingsData = (
+  data: Api.GetUserSettingsRequestData,
+): Promise<Response<Api.UserSettingsResponseData>> => {
+  return xhr.get(`/api/user/settings/${data.id}`)
+}
+
+const updateUserSettings = (
+  data: Api.UpdateUserSettingsRequestData,
+): Promise<Response<Api.UserSettingsResponseData>> => {
+  return xhr.post('/api/user/settings', {
+    headers: JSON_HEADERS,
+    body: JSON.stringify(data),
+  })
+}
+
 const getFeaturedTeaserData = (
   // no args
 ): Promise<Response<Api.FeaturedTeasersResponseData>> => {
@@ -200,7 +215,7 @@ const uploadAvatar = (
 ): Promise<Response<UserAvatar>> => {
   const formData = new FormData()
   formData.append('file', data.file)
-  return xhr.post('/api/upload-avatar', {
+  return xhr.post('/api/user/upload-avatar', {
     body: formData,
     onUploadProgress: (evt: ProgressEvent<XMLHttpRequestEventTarget>): void => {
       data.onProgress(evt.loaded / evt.total)
@@ -211,7 +226,7 @@ const uploadAvatar = (
 const deleteAvatar = (
   data: Api.DeleteAvatarRequestData,
 ): Promise<Response<UserAvatar>> => {
-  return xhr.post('/api/delete-avatar', {
+  return xhr.post('/api/user/delete-avatar', {
     headers: JSON_HEADERS,
     body: JSON.stringify(data),
   })
@@ -227,6 +242,8 @@ export default {
   getAnnouncements,
   getFeaturedData,
   getUserProfileData,
+  getUserSettingsData,
+  updateUserSettings,
   getFeaturedTeaserData,
   images,
   indexData,

--- a/frontend/src/components/Leaderboard.vue
+++ b/frontend/src/components/Leaderboard.vue
@@ -27,7 +27,13 @@
           <router-link
             :to="{ name: 'user', params: { id: row.user_id } }"
             target="_blank"
+            class="d-flex align-center"
           >
+            <UserAvatarIcon
+              :size="24"
+              :avatar-url="row.avatar_url"
+              class="mr-1"
+            />
             {{ row.user_name }}
           </router-link>
         </td>
@@ -65,6 +71,7 @@
 <script setup lang="ts">
 import type { Leaderboard } from '@common/Types'
 import RankIcon from './RankIcon.vue'
+import UserAvatarIcon from './UserAvatarIcon.vue'
 
 defineProps<{
   lb: Leaderboard

--- a/frontend/src/components/Nav.vue
+++ b/frontend/src/components/Nav.vue
@@ -49,7 +49,12 @@
             class="user-welcome-message"
             @click="drawerUser = !drawerUser"
           >
-            Hello, {{ me.name }}
+            <UserAvatarIcon
+              v-if="me.avatar"
+              :avatar-url="me.avatar.url"
+              :size="32"
+              class="mr-2"
+            /> {{ me.name }}
           </v-btn>
           <v-btn
             v-else
@@ -90,16 +95,6 @@
           <v-icon icon="mdi-chat-outline" /> Discord
         </v-list-item>
         <v-divider />
-        <v-list-item>
-          <v-checkbox
-            :model-value="showNsfw"
-            color="primary"
-            hide-details
-            density="compact"
-            label="Show NSFW Content"
-            @update:model-value="toggleNsfw"
-          />
-        </v-list-item>
       </v-list>
     </v-navigation-drawer>
 
@@ -114,6 +109,12 @@
           :to="{ name: 'admin' }"
         >
           <v-icon icon="mdi-security" /> Admin
+        </v-list-item>
+        <v-list-item
+          v-if="me"
+          :to="{ name: 'settings' }"
+        >
+          <v-icon icon="mdi-cog" /> Settings
         </v-list-item>
         <v-list-item
           v-if="me"
@@ -135,14 +136,13 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useRoute } from 'vue-router'
-import { onLoginStateChange, useNsfw, logout, loggedIn, me, isAdmin } from '../user'
+import { onLoginStateChange, logout, loggedIn, me, isAdmin } from '../user'
 import AnnouncementsDrawer from './AnnouncementsDrawer.vue'
 import AnnouncementsIcon from './AnnouncementsIcon.vue'
 import { useDialog } from '../useDialog'
+import UserAvatarIcon from './UserAvatarIcon.vue'
 
 const { openLoginDialog, currentDialog } = useDialog()
-
-const { showNsfw, toggleNsfw } = useNsfw()
 
 const route = useRoute()
 const showNav = computed(() => {

--- a/frontend/src/components/UserAvatar.vue
+++ b/frontend/src/components/UserAvatar.vue
@@ -1,0 +1,65 @@
+<template>
+  <div
+    v-if="canEdit"
+    class="avatar"
+    :class="{ 'no-avatar': !userAvatar, 'is-clickable': canEdit }"
+    :style="avatarStyle"
+    @click="onAvatarClick"
+  >
+    <v-icon
+      v-if="canEdit && userAvatar"
+      v-tooltip="'Delete this avatar'"
+      icon="mdi-trash-can"
+      @click.stop="onDeleteAvatarClick"
+    />
+    <span v-else>
+      Click to upload your avatar.
+    </span>
+  </div>
+  <div
+    v-else
+    class="avatar"
+    :class="{ 'no-avatar': !userAvatar }"
+    :style="avatarStyle"
+  />
+</template>
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { UserAvatar } from '@common/Types'
+import { resizeUrl } from '@common/ImageService'
+
+const props = defineProps<{
+  canEdit: boolean
+  userAvatar: UserAvatar | null
+}>()
+
+const emit = defineEmits<{
+  (e: 'avatarClick'): void
+  (e: 'deleteClick'): void
+}>()
+
+const onDeleteAvatarClick = () => {
+  if (!props.canEdit) {
+    return
+  }
+  emit('deleteClick')
+}
+
+const onAvatarClick = () => {
+  if (!props.canEdit) {
+    return
+  }
+  emit('avatarClick')
+}
+
+const avatarStyle = computed(() => {
+  const imgUrl = props.userAvatar?.url
+  if (!imgUrl) {
+    return null
+  }
+
+  return {
+    backgroundImage: `url(${resizeUrl(imgUrl, 400, 400, 'cover')})`,
+  }
+})
+</script>

--- a/frontend/src/components/UserAvatarIcon.vue
+++ b/frontend/src/components/UserAvatarIcon.vue
@@ -1,0 +1,28 @@
+<template>
+  <div
+    class="avatar-icon"
+    :style="avatarStyle"
+  />
+</template>
+<script setup lang="ts">
+import { computed } from 'vue'
+import { resizeUrl } from '@common/ImageService'
+
+const props = defineProps<{
+  avatarUrl: string | null,
+  size: number,
+}>()
+
+const avatarStyle = computed(() => {
+  const imgUrl = props.avatarUrl
+  if (!imgUrl) {
+    return null
+  }
+
+  return {
+    backgroundImage: `url(${resizeUrl(imgUrl, props.size * 2, props.size * 2, 'cover')})`,
+    width: `${props.size}px`,
+    height: `${props.size}px`,
+  }
+})
+</script>

--- a/frontend/src/components/dialogs/EditImageDialog.vue
+++ b/frontend/src/components/dialogs/EditImageDialog.vue
@@ -56,7 +56,6 @@
           <div>
             <v-checkbox
               v-model="isPublic"
-              :disabled="isNsfw"
               density="comfortable"
               label="Public Image (The image will be visible in the gallery for other users to use.)"
             />
@@ -65,7 +64,7 @@
             <v-checkbox
               v-model="isNsfw"
               density="comfortable"
-              label="NSFW Image (Check this if the image is not safe for work. NSFW images will be private automatically.)"
+              label="NSFW Image (Check this if the image is not safe for work.)"
             />
           </div>
 
@@ -92,7 +91,7 @@
   </v-card>
 </template>
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { ref, watch } from 'vue'
 import type { ImageInfo, Tag } from '@common/Types'
 import TagsInput from '../TagsInput.vue'
 import ResponsiveImage from '../ResponsiveImage.vue'
@@ -107,10 +106,6 @@ const tags = ref<string[]>([])
 const isPublic = ref<boolean>(false)
 const isNsfw = ref<boolean>(false)
 
-const isPrivate = computed((): boolean => {
-  return !isPublic.value || isNsfw.value
-})
-
 const init = (image: ImageInfo | undefined) => {
   if (!image) return
 
@@ -118,7 +113,7 @@ const init = (image: ImageInfo | undefined) => {
   copyrightName.value = image.copyrightName
   copyrightURL.value = image.copyrightURL
   tags.value = image.tags.map((t: Tag) => t.title)
-  isPublic.value = !image.private && !image.nsfw
+  isPublic.value = !image.private
   isNsfw.value = image.nsfw
 }
 
@@ -131,7 +126,7 @@ const saveImage = async () => {
     copyrightName: copyrightName.value,
     copyrightURL: copyrightURL.value,
     tags: tags.value,
-    isPrivate: isPrivate.value,
+    isPrivate: !isPublic.value,
     isNsfw: isNsfw.value,
   })
 }

--- a/frontend/src/components/dialogs/NewImageDialog.vue
+++ b/frontend/src/components/dialogs/NewImageDialog.vue
@@ -96,7 +96,6 @@
           <div>
             <v-checkbox
               v-model="isPublic"
-              :disabled="isNsfw"
               density="comfortable"
               label="Public Image (As soon as the image gets approved, it will be visible in the gallery for other users to use.)"
             />
@@ -105,13 +104,13 @@
             <v-checkbox
               v-model="isNsfw"
               density="comfortable"
-              label="NSFW Image (Check this if the image is not safe for work. NSFW images will be private automatically.)"
+              label="NSFW Image (Check this if the image is not safe for work.)"
             />
           </div>
 
           <v-card-actions>
             <!-- isPrivate -->
-            <template v-if="!isPublic || isNsfw">
+            <template v-if="!isPublic">
               <v-btn
                 v-if="newImageUploading"
                 variant="elevated"
@@ -222,10 +221,6 @@ const isPublic = ref<boolean>(false)
 const isNsfw = ref<boolean>(false)
 const droppable = ref<boolean>(false)
 const inputFocused = ref<boolean>(false)
-
-const isPrivate = computed((): boolean => {
-  return !isPublic.value || isNsfw.value
-})
 
 const uploadProgressPercent = computed((): number => {
   return newImageUploadProgress.value ? Math.round(newImageUploadProgress.value * 100) : 0
@@ -341,7 +336,7 @@ const postToGallery = async () => {
     copyrightName: copyrightName.value,
     copyrightURL: copyrightURL.value,
     tags: tags.value,
-    isPrivate: isPrivate.value,
+    isPrivate: !isPublic.value,
     isNsfw: isNsfw.value,
   })
   reset()
@@ -358,7 +353,7 @@ const setupGameClick = async () => {
     copyrightName: copyrightName.value,
     copyrightURL: copyrightURL.value,
     tags: tags.value,
-    isPrivate: isPrivate.value,
+    isPrivate: !isPublic.value,
     isNsfw: isNsfw.value,
   })
   reset()

--- a/frontend/src/components/dialogs/UserAvatarUploadDialog.vue
+++ b/frontend/src/components/dialogs/UserAvatarUploadDialog.vue
@@ -43,11 +43,6 @@
                   <li>Paste an image URL</li>
                   <li>Paste an image</li>
                 </ul>
-                <div class="text-disabled">
-                  The avatar will be resized to a square of 400x400 pixels,
-                  even if you upload a different resolution. To prevent
-                  cutting off your avatar, please upload a square image.
-                </div>
               </div>
             </label>
           </div>

--- a/frontend/src/components/teasers/FinishedGameTeaser.vue
+++ b/frontend/src/components/teasers/FinishedGameTeaser.vue
@@ -122,12 +122,10 @@ const shapeMode = computed(() => shapeModeToString(props.game.shapeMode))
 
 const rotationMode = computed(() => rotationModeToString(props.game.rotationMode))
 
-const { showNsfw } = useNsfw()
-
+const { nsfwUnblurred } = useNsfw()
 const nsfwToggled = ref<boolean>(false)
-const hoverable = computed(() => (!props.game.image.nsfw || showNsfw.value || nsfwToggled.value))
-const showNsfwInfo = computed(() => props.game.image.nsfw && !showNsfw.value && !nsfwToggled.value)
-
+const hoverable = computed(() => (!props.game.image.nsfw || nsfwUnblurred.value || nsfwToggled.value))
+const showNsfwInfo = computed(() => props.game.image.nsfw && !nsfwUnblurred.value && !nsfwToggled.value)
 const time = (start: number, end: number) => {
   const from = start
   const to = end || Time.timestamp()

--- a/frontend/src/components/teasers/ImageTeaser.vue
+++ b/frontend/src/components/teasers/ImageTeaser.vue
@@ -90,8 +90,6 @@ import { me, useNsfw } from '../../user'
 
 const { openReportImageDialog } = useDialog()
 
-const { showNsfw } = useNsfw()
-
 const props = withDefaults(defineProps<{
   image: ImageInfo
   edit?: boolean
@@ -99,9 +97,10 @@ const props = withDefaults(defineProps<{
   edit: true,
 })
 
+const { nsfwUnblurred } = useNsfw()
 const nsfwToggled = ref<boolean>(false)
-const hoverable = computed(() => (!props.image.nsfw || showNsfw.value || nsfwToggled.value))
-const showNsfwInfo = computed(() => props.image.nsfw && !showNsfw.value && !nsfwToggled.value)
+const hoverable = computed(() => (!props.image.nsfw || nsfwUnblurred.value || nsfwToggled.value))
+const showNsfwInfo = computed(() => props.image.nsfw && !nsfwUnblurred.value && !nsfwToggled.value)
 
 const emit = defineEmits<{
   (event: 'click'): void

--- a/frontend/src/components/teasers/RunningGameTeaser.vue
+++ b/frontend/src/components/teasers/RunningGameTeaser.vue
@@ -144,10 +144,10 @@ const shapeMode = computed(() => shapeModeToString(props.game.shapeMode))
 
 const rotationMode = computed(() => rotationModeToString(props.game.rotationMode))
 
-const { showNsfw } = useNsfw()
+const { nsfwUnblurred } = useNsfw()
 const nsfwToggled = ref<boolean>(false)
-const hoverable = computed(() => (!props.game.image.nsfw || showNsfw.value || nsfwToggled.value))
-const showNsfwInfo = computed(() => props.game.image.nsfw && !showNsfw.value && !nsfwToggled.value)
+const hoverable = computed(() => (!props.game.image.nsfw || nsfwUnblurred.value || nsfwToggled.value))
+const showNsfwInfo = computed(() => props.game.image.nsfw && !nsfwUnblurred.value && !nsfwToggled.value)
 
 const time = ((start: number, end: number) => {
   const from = start

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -5,6 +5,7 @@ import App from './App.vue'
 import Index from './views/Index.vue'
 import NewGame from './views/NewGame.vue'
 import FeaturedView from './views/FeaturedView.vue'
+import SettingsView from './views/SettingsView.vue'
 import Game from './views/Game.vue'
 import Replay from './views/Replay.vue'
 import CannyBugReportsView from './views/CannyBugReports.vue'
@@ -58,6 +59,7 @@ const run = async () => {
       { name: 'featured-artist', path: '/featured-artist/:artist', component: FeaturedView, meta: { title: 'Featured Artist' } },
       { name: 'featured-category', path: '/featured-category/:category', component: FeaturedView, meta: { title: 'Featured Category' } },
       { name: 'user', path: '/user/:id', component: PublicUserProfile, meta: { title: 'User Profile' } },
+      { name: 'settings', path: '/settings', component: SettingsView, meta: { title: 'Settings' } },
 
       // Canny.io feedback
       { path: '/feedback', redirect: { name: 'bug-reports' } },

--- a/frontend/src/style.scss
+++ b/frontend/src/style.scss
@@ -309,7 +309,7 @@ $bg-color-transparent: rgba(0 0 0 / 70%);
     }
 
     .game-teaser-image {
-      filter: blur(120px);
+      filter: blur(20px);
     }
 
     .game-teaser-buttons {
@@ -462,7 +462,7 @@ $bg-color-transparent: rgba(0 0 0 / 70%);
     }
 
     .game-teaser-image {
-      filter: blur(120px);
+      filter: blur(20px);
     }
 
     .game-teaser-buttons {
@@ -696,7 +696,7 @@ html.view-replay body { overflow: hidden; }
     overflow: hidden;
 
     .imageteaser {
-      filter: blur(120px);
+      filter: blur(20px);
     }
   }
 }
@@ -1208,44 +1208,6 @@ fieldset {
     white-space: nowrap;
   }
 
-  .avatar-cell {
-    padding: 0;
-    vertical-align: top;
-  }
-
-  .avatar {
-    background-size: contain;
-    aspect-ratio: 1;
-    margin: 30px 15px;
-    width: 200px;
-    display: inline-block;
-
-    i {
-      display: none;
-      position: absolute;
-    }
-
-    &:hover i {
-      display: block;
-    }
-  }
-
-  .avatar.no-avatar {
-    background-image: url('assets/gfx/hyottokun.png');
-    filter: grayscale(1);
-    opacity: .3;
-    position: relative;
-
-    span {
-      position: absolute;
-      top: -1em;
-      width: 100%;
-      display: block;
-      text-align: center;
-      user-select: none;
-    }
-  }
-
   .text-disabled {
     color: rgba(10 10 10 / var(--v-disabled-opacity)) !important;
   }
@@ -1287,4 +1249,52 @@ fieldset {
 
 .image-is-rejected-info {
   background: rgba(185 84 84 / 80%);
+}
+
+
+
+.avatar-cell {
+  padding: 0;
+  vertical-align: top;
+
+}
+
+.avatar-icon {
+  background-size: contain;
+  aspect-ratio: 1;
+  margin: 0;
+  display: inline-block;
+}
+
+.avatar {
+  background-size: contain;
+  aspect-ratio: 1;
+  margin: 30px 15px;
+  width: 200px;
+  display: inline-block;
+
+  i {
+    display: none;
+    position: absolute;
+  }
+
+  &:hover i {
+    display: block;
+  }
+}
+
+.avatar.no-avatar {
+  background-image: url('assets/gfx/hyottokun.png');
+  filter: grayscale(1);
+  opacity: .3;
+  position: relative;
+
+  span {
+    position: absolute;
+    top: -1em;
+    width: 100%;
+    display: block;
+    text-align: center;
+    user-select: none;
+  }
 }

--- a/frontend/src/user.ts
+++ b/frontend/src/user.ts
@@ -4,24 +4,24 @@ import _api from './_api'
 import storage from './storage'
 import xhr from './_api/xhr'
 import { PLAYER_SETTINGS } from '@common/Types'
-import type { ClientId, User } from '@common/Types'
+import type { ClientId, Me } from '@common/Types'
 import { computed, ref } from 'vue'
 import Time from '@common/Time'
 
-const showNsfw = ref(storage.getBool('showNsfw', false))
-const toggleNsfw = (): void => {
-  showNsfw.value = !showNsfw.value
-  storage.setBool('showNsfw', showNsfw.value)
+const nsfwUnblurred = ref(storage.getBool('showNsfw', false))
+const setNsfwUnblurred = (newValue: boolean): void => {
+  nsfwUnblurred.value = newValue
+  storage.setBool('showNsfw', nsfwUnblurred.value)
 }
 
 export const useNsfw = () => {
   return {
-    showNsfw,
-    toggleNsfw,
+    nsfwUnblurred,
+    setNsfwUnblurred,
   }
 }
 
-export const me = ref<null | User>(null)
+export const me = ref<null | Me>(null)
 export const loggedIn = computed<boolean>(() => !!(me.value && me.value.type === 'user'))
 export const isAdmin = computed<boolean>(() => !!(me.value?.groups.includes('admin')))
 
@@ -67,11 +67,13 @@ export async function init(): Promise<void> {
     if ('reason' in data) {
       // console.log('not logged in')
       me.value = null
+      setNsfwUnblurred(false)
       eventBus.emit('logout')
     } else {
       // console.log('logged in (reg or guest)')
       xhr.setClientId(data.user.clientId)
       me.value = data.user
+      setNsfwUnblurred(data.user.nsfwUnblurred)
       eventBus.emit('login')
     }
   } catch {
@@ -174,7 +176,6 @@ async function changePassword(
     return { error: 'Unknown error' }
   }
 }
-
 
 export const api = {
   logout,

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -1,0 +1,186 @@
+<template>
+  <div v-if="!me || !loggedIn">
+    Please log in to access your settings.
+  </div>
+  <div v-else-if="!data">
+    Loading...
+  </div>
+  <div v-else-if="'reason' in data">
+    {{ data.reason }}
+  </div>
+  <div v-else>
+    <v-table v-if="data">
+      <tbody>
+        <tr>
+          <th>Avatar</th>
+          <td
+            class="avatar-cell"
+          >
+            <UserAvatar
+              :can-edit="true"
+              :user-avatar="avatar"
+              @avatar-click="onAvatarClick"
+              @delete-click="onAvatarDeleteClick"
+            />
+          </td>
+          <td class="text-disabled">
+            <ul>
+              <li>The avatar will be resized to a square, even if you upload a different aspect ratio.</li>
+              <li>To prevent cutting off your avatar, please upload a square image.</li>
+              <li>The avatar will be displayed on your profile page and next to your name in various places.</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th>Enable NSFW Content</th>
+          <td>
+            <v-checkbox
+              v-model="nsfwActive"
+              density="comfortable"
+            />
+          </td>
+          <td class="text-disabled">
+            <ul>
+              <li>NSFW Content you upload yourself will always be available to you, regardless of this setting.</li>
+              <li>If you check this, you will see public NSFW content uploaded by other users as well.</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th>Unblur NSFW Content</th>
+          <td>
+            <v-checkbox
+              v-model="nsfwUnblurred"
+              density="comfortable"
+            />
+          </td>
+          <td class="text-disabled">
+            <ul>
+              <li>Check this if you want NSFW content to be unblurred by default.</li>
+              <li>If you leave this unchecked, you can always choose to unblur content on a case-by-case basis.</li>
+            </ul>
+          </td>
+        </tr>
+      </tbody>
+    </v-table>
+  </div>
+</template>
+<script setup lang="ts">
+import type { WatchHandle } from 'vue'
+import { onMounted, onUnmounted, ref, watch } from 'vue'
+import UserAvatar from '../components/UserAvatar.vue'
+import { init, loggedIn, me, onLoginStateChange, useNsfw } from '../user'
+import api from '../_api'
+import type { Api, UserAvatar as UserAvatarType } from '@common/Types'
+import { useDialog } from '../useDialog'
+import { uploadAvatar } from '../upload'
+import { toast } from '../toast'
+
+const { closeDialog, openUserAvatarUploadDialog } = useDialog()
+const { setNsfwUnblurred } = useNsfw()
+
+const data = ref<null | Api.UserSettingsResponseData>(null)
+
+const avatar = ref<UserAvatarType | null>(null)
+const nsfwActive = ref<boolean>(false)
+const nsfwUnblurred = ref<boolean>(false)
+
+let stopWatch: WatchHandle | null = null
+const onInit = async () => {
+  if (!me.value || !me.value.id) {
+    avatar.value = null
+    nsfwActive.value = false
+    nsfwUnblurred.value = false
+    data.value = null
+    return
+  }
+
+  const res = await api.pub.getUserSettingsData({ id: me.value.id })
+
+  data.value = await res.json()
+
+  if (stopWatch) {
+    stopWatch()
+    stopWatch = null
+  }
+
+  if ('reason' in data.value) {
+    avatar.value = null
+    nsfwActive.value = false
+    nsfwUnblurred.value = false
+  } else {
+    avatar.value = data.value.userSettings.avatar
+    nsfwActive.value = data.value.userSettings.nsfwActive
+    nsfwUnblurred.value = data.value.userSettings.nsfwUnblurred
+  }
+
+  stopWatch = watch([nsfwActive, nsfwUnblurred], async ([newNsfwActive, newNsfwUnblurred]) => {
+    setNsfwUnblurred(newNsfwUnblurred)
+    const res = await api.pub.updateUserSettings({
+      nsfwActive: newNsfwActive,
+      nsfwUnblurred: newNsfwUnblurred,
+    })
+    const resData = await res.json()
+    if ('reason' in resData) {
+      toast('An error occured while updating settings: ' + resData.reason, 'error')
+      return
+    }
+    toast('Settings updated.', 'success')
+    await init()
+  }, { deep: true })
+}
+
+const onAvatarClick = () => {
+  const onSaveClick = async (blob: Blob): Promise<void> => {
+    const result = await uploadAvatar(blob)
+
+    if ('error' in result) {
+      toast(result.error, 'error')
+      return
+    }
+
+    closeDialog()
+    toast('Avatar uploaded successfully.', 'success')
+    if (data.value && !('reason' in data.value)) {
+      avatar.value = result.avatar
+    }
+    await init()
+  }
+
+  openUserAvatarUploadDialog({
+    onSaveClick,
+  })
+}
+
+const onAvatarDeleteClick = async () => {
+  if (!data.value || 'reason' in data.value) {
+    return
+  }
+  const avatarId = data.value.userSettings.avatarId
+  if (avatarId && confirm('Really delete the Avatar?')) {
+    const res = await api.pub.deleteAvatar({
+      avatarId,
+    })
+
+    if (res.status !== 200) {
+      toast('An error occured during avatar deletion.', 'error')
+      return
+    }
+
+    toast('Avatar deleted successfully.', 'success')
+    avatar.value = null
+    await init()
+  }
+}
+
+
+let offLoginStateChange: () => void = () => {}
+onMounted(async () => {
+  await onInit()
+  offLoginStateChange = onLoginStateChange(onInit)
+})
+
+onUnmounted(() => {
+  offLoginStateChange()
+})
+</script>

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1950,6 +1950,7 @@
       "integrity": "sha512-6/cmF2piao+f6wSxUsJLZjck7OQsYyRtcOZS02k7XINSNlz93v6emM8WutDQSXnroG2xwYlEVHJI+cPA7CPM3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.0",
         "@typescript-eslint/types": "8.50.0",
@@ -6432,6 +6433,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/server/src/GameService.ts
+++ b/server/src/GameService.ts
@@ -230,20 +230,20 @@ export class GameService {
     return games
   }
 
-  public async getPublicRunningGames(offset: number, limit: number, currentUserId: UserId, limitToUserId: UserId | null): Promise<GameRow[]> {
-    return await this.server.repos.games.getPublicRunningGames(offset, limit, currentUserId, limitToUserId)
+  public async getPublicRunningGames(offset: number, limit: number, currentUserId: UserId, limitToUserId: UserId | null, showNsfw: boolean): Promise<GameRow[]> {
+    return await this.server.repos.games.getPublicRunningGames(offset, limit, currentUserId, limitToUserId, showNsfw)
   }
 
-  public async getPublicFinishedGames(offset: number, limit: number, currentUserId: UserId, limitToUserId: UserId | null): Promise<GameRow[]> {
-    return await this.server.repos.games.getPublicFinishedGames(offset, limit, currentUserId, limitToUserId)
+  public async getPublicFinishedGames(offset: number, limit: number, currentUserId: UserId, limitToUserId: UserId | null, showNsfw: boolean): Promise<GameRow[]> {
+    return await this.server.repos.games.getPublicFinishedGames(offset, limit, currentUserId, limitToUserId, showNsfw)
   }
 
-  public async countPublicRunningGames(currentUserId: UserId): Promise<number> {
-    return await this.server.repos.games.countPublicRunningGames(currentUserId)
+  public async countPublicRunningGames(currentUserId: UserId, showNsfw: boolean): Promise<number> {
+    return await this.server.repos.games.countPublicRunningGames(currentUserId, showNsfw)
   }
 
-  public async countPublicFinishedGames(currentUserId: UserId): Promise<number> {
-    return await this.server.repos.games.countPublicFinishedGames(currentUserId)
+  public async countPublicFinishedGames(currentUserId: UserId, showNsfw: boolean): Promise<number> {
+    return await this.server.repos.games.countPublicFinishedGames(currentUserId, showNsfw)
   }
 
   private async exists(gameId: GameId): Promise<boolean> {

--- a/server/src/Images.ts
+++ b/server/src/Images.ts
@@ -75,8 +75,9 @@ export class Images {
     limit: number,
     currentUserId: UserId | null,
     limitToUserId: UserId | null,
+    showNsfw: boolean,
   ): Promise<ImageInfo[]> {
-    const rows = await this.imagesRepo.searchImagesWithCount(search, orderBy, offset, limit, currentUserId, limitToUserId)
+    const rows = await this.imagesRepo.searchImagesWithCount(search, orderBy, offset, limit, currentUserId, limitToUserId, showNsfw)
     const tags = await this.imagesRepo.getTagsByImageIds(rows.map(row => row.id))
     return rows.map(row => this.imageWithCountToImageInfo(row, tags))
   }

--- a/server/src/UploadRequestsManager.ts
+++ b/server/src/UploadRequestsManager.ts
@@ -1,0 +1,42 @@
+import multer from 'multer'
+import config from './Config'
+import Util from '@common/Util'
+import express from 'express'
+
+export class UploadRequestsManager {
+  public static serveUploadsRequestHandler() {
+    return express.static(config.dir.UPLOAD_DIR)
+  }
+
+  public static createUploadRequestHandler() {
+    const storage = multer.diskStorage({
+      destination: config.dir.UPLOAD_DIR,
+      filename: function (_req, file, cb) {
+        const basename = UploadRequestsManager.basename(file)
+        const extension = UploadRequestsManager.extension(file)
+
+        cb(null, `${basename}${extension}`)
+      },
+    })
+    return multer({ storage }).single('file')
+  }
+
+  private static basename(file: Express.Multer.File) {
+    return `${Util.uniqId()}-${Util.hash(file.originalname)}`
+  }
+
+  private static extension(file: Express.Multer.File) {
+    switch (file.mimetype) {
+      case 'image/png': return '.png'
+      case 'image/jpeg': return '.jpeg'
+      case 'image/webp': return '.webp'
+      case 'image/gif': return '.gif'
+      case 'image/svg+xml': return '.svg'
+      default: {
+        // try to keep original filename
+        const m = file.filename.match(/\.[a-z]+$/)
+        return m ? m[0] : '.unknown'
+      }
+    }
+  }
+}

--- a/server/src/in-memory/UserSettingsCache.ts
+++ b/server/src/in-memory/UserSettingsCache.ts
@@ -1,0 +1,23 @@
+import type { UserId, UserSettings } from '@common/Types'
+
+class UserSettingsCache {
+  private cache = new Map<UserId, UserSettings>()
+
+  get(userId: UserId): UserSettings | null {
+    return this.cache.get(userId) || null
+  }
+
+  set(userId: UserId, settings: UserSettings): void {
+    this.cache.set(userId, settings)
+  }
+
+  invalidate(userId: UserId): void {
+    this.cache.delete(userId)
+  }
+
+  invalidateAll(): void {
+    this.cache.clear()
+  }
+}
+
+export default new UserSettingsCache()

--- a/server/src/repo/ImagesRepo.ts
+++ b/server/src/repo/ImagesRepo.ts
@@ -163,6 +163,7 @@ export class ImagesRepo {
     limit: number,
     currentUserId: UserId | null,
     limitToUserId: UserId | null,
+    showNsfw: boolean,
   ): Promise<ImageRowWithCount[]> {
     const orderByMap = {
       [ImageSearchSort.ALPHA_ASC]: [{ title: 1 }, { created: -1 }],
@@ -242,6 +243,7 @@ export class ImagesRepo {
           (i.private = 0 AND i.state = 'approved')
           ${currentUserId ? `OR i.uploader_user_id = $${idxCurrentUserId}` : ''}
         )
+        ${!showNsfw ? (idxCurrentUserId ? ` AND (i.nsfw = 0 OR i.uploader_user_id = $${idxCurrentUserId || 0})` : ' AND i.nsfw = 0') : '' }
         ${limitToUserId ? ` AND i.uploader_user_id = $${idxLimitToUserId}` : ''}
         ${ors.length > 0 ? ` AND (${ors.join(' OR ')})` : ''}
       ${this.db._buildOrderBy(orderByMap[orderBy])}

--- a/server/src/web_routes/api/logged-in-users.ts
+++ b/server/src/web_routes/api/logged-in-users.ts
@@ -1,0 +1,178 @@
+import type { Api, UserId, UserRow } from '@common/Types'
+import type { NextFunction } from 'express'
+import express from 'express'
+import { logger, newJSONDateString } from '@common/Util'
+import { COOKIE_TOKEN } from '../../Auth'
+import type { Server } from '../../Server'
+import type { DeleteAvatarRequestData } from '@common/TypesApi'
+import { UploadRequestsManager } from '../../UploadRequestsManager'
+
+const log = logger('web_routes/api/index.ts')
+
+const requireLoggedInUserApi = (req: express.Request, res: express.Response, next: NextFunction) => {
+  if (!req.userInfo?.token) {
+    res.status(401).send({})
+    return
+  }
+  const user = req.userInfo.user || null
+  if (!user || !user.id) {
+    res.status(403).send({ ok: false, error: 'forbidden' })
+    return
+  }
+  if (req.userInfo.user_type !== 'user') {
+    res.status(403).send({ ok: false, error: 'forbidden' })
+    return
+  }
+  next()
+}
+
+export default function createRouter(
+  server: Server,
+): express.Router {
+
+  const upload = UploadRequestsManager.createUploadRequestHandler()
+
+  const router = express.Router()
+
+  router.use(requireLoggedInUserApi)
+
+  router.post('/logout', async (req, res): Promise<void> => {
+    if (!req.userInfo?.token) {
+      const responseData: Api.LogoutResponseData = { reason: 'no token' }
+      res.status(401).send(responseData)
+      return
+    }
+    await server.repos.tokens.delete({ token: req.userInfo.token })
+    res.clearCookie(COOKIE_TOKEN)
+    const responseData: Api.LogoutResponseData = { success: true }
+    res.send(responseData)
+  })
+
+  router.get('/settings/:id', async (req, res): Promise<void> => {
+    if (req.userInfo?.user_type !== 'user') {
+      res.status(403).send({ reason: 'forbidden' })
+      return
+    }
+
+    const currentUserId = req.userInfo?.user?.id ?? 0 as UserId
+    const limitToUserId = parseInt(`${req.params.id}`, 10) as UserId
+    if (limitToUserId !== currentUserId) {
+      res.status(403).send({ reason: 'forbidden' })
+      return
+    }
+
+    try {
+      const responseData: Api.UserSettingsResponseData = {
+        userSettings: await server.users.getCompleteUserSettings(currentUserId),
+      }
+      res.send(responseData)
+    } catch (e: unknown) {
+      res.status(404).send({ reason: e instanceof Error ? e.message : String(e) })
+    }
+  })
+
+  router.post('/settings', express.json(), async (req, res): Promise<void> => {
+    const user: UserRow | null = req.userInfo?.user || null
+    if (!user || !user.id || req.userInfo?.user_type !== 'user') {
+      res.status(403).send({ ok: false, error: 'forbidden' })
+      return
+    }
+
+    const data = req.body as Api.UpdateUserSettingsRequestData
+
+    try {
+      const userSettings = await server.repos.users.getUserSettings(user.id)
+
+      await server.repos.users.updateUserSettings({
+        userId: user.id,
+        avatarId: userSettings.avatarId,
+        nsfwActive: data.nsfwActive,
+        nsfwUnblurred: data.nsfwUnblurred,
+      })
+      const responseData: Api.UserSettingsResponseData = {
+        userSettings: await server.users.getCompleteUserSettings(user.id),
+      }
+      res.send(responseData)
+    } catch (e: unknown) {
+      res.status(404).send({ reason: e instanceof Error ? e.message : String(e) })
+    }
+  })
+
+  router.post('/delete-avatar', express.json(), async (req: express.Request, res): Promise<void> => {
+    const user: UserRow | null = req.userInfo?.user || null
+    if (!user || !user.id) {
+      res.status(403).send({ ok: false, error: 'forbidden' })
+      return
+    }
+
+    const data = req.body as DeleteAvatarRequestData
+
+    try {
+      const settings = await server.repos.users.getUserSettings(user.id)
+
+      // make sure the avatar id is the one the
+      // user (making the request) currently has set
+      if (settings.avatarId !== data.avatarId) {
+        res.status(403).send({ ok: false, error: 'forbidden' })
+        return
+      }
+
+      settings.avatarId = null
+      await server.repos.users.updateUserSettings(settings)
+
+      await server.users.deleteAvatar(data.avatarId)
+
+      res.send({ ok: true })
+    } catch {
+      res.status(400).send('Something went wrong!')
+    }
+  })
+
+  router.post('/upload-avatar', (req, res): void => {
+    void upload(req, res, async (err: unknown): Promise<void> => {
+      if (err) {
+        log.log('/api/user/upload-avatar', 'error', err)
+        res.status(400).send('Something went wrong!')
+        return
+      }
+      if (!req.file) {
+        log.log('/api/user/upload-avatar', 'error', 'no file')
+        res.status(400).send('Something went wrong!')
+        return
+      }
+
+      log.info('req.file.filename', req.file.filename)
+
+      const im = server.images
+
+      const user = await server.users.getOrCreateUserByRequest(req)
+
+      const imagePath = im.getImagePath(req.file.filename)
+      const dim = await im.getDimensions(imagePath)
+
+      try {
+        const userSettings = await server.repos.users.getUserSettings(user.id)
+
+        const avatarId = await server.repos.users.saveAvatar({
+          created: newJSONDateString(),
+          filename: req.file.filename,
+          filename_original: req.file.originalname,
+          width: dim.w,
+          height: dim.h,
+        })
+
+        userSettings.avatarId = avatarId
+
+        await server.repos.users.updateUserSettings(userSettings)
+
+        const avatar = await server.repos.users.getUserAvatarByUserId(user.id)
+
+        res.send(avatar)
+      } catch {
+        res.status(400).send('Something went wrong!')
+      }
+    })
+  })
+
+  return router
+}


### PR DESCRIPTION
Those are hidden by default for non-logged-in users and users who
have not enabled nsfw content.
Users will see their own uploads regardless of nsfw settings.
However, all nsfw content is blurred on the overview pages unless the
user has explicitly changed the setting to unblurred.

Additionally, showing the user avatar in the leaderboard and nav menu now.
