### PR TITLE
feat: trust-based auto-approval for uploaded images

### DIFF
--- a/common/src/Types.ts
+++ b/common/src/Types.ts
@@ -382,6 +382,7 @@ export interface ImageInfo {
   reported: number
   nsfw: boolean
   state: 'pending_approval' | 'rejected' | 'approved'
+  rejectReason: string
 }
 
 export const defaultImageInfo = (): ImageInfo => ({
@@ -402,6 +403,7 @@ export const defaultImageInfo = (): ImageInfo => ({
   reported: 0,
   nsfw: false,
   state: 'pending_approval',
+  rejectReason: '',
 })
 
 export interface PuzzleInfo {
@@ -870,6 +872,7 @@ export interface ImageRow {
   nsfw: number
   checksum: string | null
   state: 'pending_approval' | 'rejected' | 'approved'
+  reject_reason: string
 }
 
 export interface ImageXTagRow {
@@ -892,12 +895,25 @@ export interface ImageRowWithCount extends ImageRow {
   uploader_user_name: string
 }
 
+export interface UploaderInfo {
+  id: UserId
+  name: string
+  trusted: number
+  trustManuallySet: number
+  approvedCount: number
+  rejectedCount: number
+  pendingCount: number
+  totalCount: number
+}
+
 export interface UserRow {
   id: UserId
   created: JSONDateString
   client_id: ClientId
   name: string
   email: string
+  trusted: number
+  trust_manually_set: number
 }
 
 export interface UserGroupRow {

--- a/common/src/TypesAdminApi.ts
+++ b/common/src/TypesAdminApi.ts
@@ -1,4 +1,4 @@
-import type { Announcement, FeaturedRow, FeaturedRowWithCollections, FeaturedTeaserRow, FixPiecesResult, GameRowWithImageAndUser, ImageInfo, ImageRowWithCount, MergeClientIdsIntoUserResult, Pagination, UserGroupRow, UserRow } from './Types'
+import type { Announcement, FeaturedRow, FeaturedRowWithCollections, FeaturedTeaserRow, FixPiecesResult, GameRowWithImageAndUser, ImageInfo, ImageRowWithCount, MergeClientIdsIntoUserResult, Pagination, UploaderInfo, UserGroupRow, UserRow } from './Types'
 
 export type ErrorResponseData = {
   error: string
@@ -62,6 +62,18 @@ export type PostUsersMergeClientIdsIntoUsersResponseData = MergeClientIdsIntoUse
 export type PostGamesFixPiecesResponseData = FixPiecesResult
 
 export type GetGroupsResponseData = UserGroupRow[]
+
+export type GetUploadersResponseData = {
+  items: UploaderInfo[]
+  pagination: Pagination
+} | ErrorResponseData
+
+export type SetUserTrustResponseData = AcknowledgeResponseData | ErrorResponseData
+
+export type RecomputeTrustResponseData = {
+  ok: true
+  count: number
+} | ErrorResponseData
 
 export type GetAnnouncementsResponseData = Announcement[]
 

--- a/config.example.json
+++ b/config.example.json
@@ -44,5 +44,8 @@
       "guildId": "GUILD/SERVER ID",
       "channelId": "CHANNEL ID"
     }
+  },
+  "trust": {
+    "threshold": 5
   }
 }

--- a/db/dbpatches/26_user_trust.sql
+++ b/db/dbpatches/26_user_trust.sql
@@ -1,0 +1,7 @@
+-- Add trusted flag to users
+ALTER TABLE users ADD COLUMN trusted INTEGER DEFAULT 0;
+-- When set, recomputeTrust will not override the admin's decision
+ALTER TABLE users ADD COLUMN trust_manually_set INTEGER DEFAULT 0;
+
+-- Add rejection reason to images
+ALTER TABLE images ADD COLUMN reject_reason TEXT DEFAULT '';

--- a/frontend/src/_api/admin.ts
+++ b/frontend/src/_api/admin.ts
@@ -86,8 +86,17 @@ const getImages = async (data: {
   offset: number
   ids?: ImageId[]
   tags?: string[]
+  uploaderUserId?: UserId
 }): Promise<Api.Admin.GetImagesResponseData> => {
   const res = await xhr.get<Api.Admin.GetImagesResponseData>(`/admin/api/images${Util.asQueryArgs(data)}`)
+  return await res.json()
+}
+
+const getPendingImages = async (data: {
+  limit: number
+  offset: number
+}): Promise<Api.Admin.GetImagesResponseData> => {
+  const res = await xhr.get<Api.Admin.GetImagesResponseData>(`/admin/api/images/pending${Util.asQueryArgs(data)}`)
   return await res.json()
 }
 
@@ -175,9 +184,11 @@ const approveImage = async (
 
 const rejectImage = async (
   id: ImageId,
+  reason?: string,
 ): Promise<Api.Admin.RejectImageResponseData> => {
   const res = await xhr.post<Api.Admin.RejectImageResponseData>(`/admin/api/images/${id}/_reject`, {
     headers: JSON_HEADERS,
+    body: JSON.stringify({ reason: reason || '' }),
   })
   return await res.json()
 }
@@ -196,6 +207,48 @@ const getGroups = async (
   return await res.json()
 }
 
+const getUploaders = async (data: {
+  limit: number
+  offset: number
+}): Promise<Api.Admin.GetUploadersResponseData> => {
+  const res = await xhr.get<Api.Admin.GetUploadersResponseData>(`/admin/api/uploaders${Util.asQueryArgs(data)}`)
+  return await res.json()
+}
+
+const trustUser = async (
+  id: UserId,
+): Promise<Api.Admin.SetUserTrustResponseData> => {
+  const res = await xhr.post<Api.Admin.SetUserTrustResponseData>(`/admin/api/users/${id}/_trust`, {
+    headers: JSON_HEADERS,
+  })
+  return await res.json()
+}
+
+const untrustUser = async (
+  id: UserId,
+): Promise<Api.Admin.SetUserTrustResponseData> => {
+  const res = await xhr.post<Api.Admin.SetUserTrustResponseData>(`/admin/api/users/${id}/_untrust`, {
+    headers: JSON_HEADERS,
+  })
+  return await res.json()
+}
+
+const resetUserTrust = async (
+  id: UserId,
+): Promise<Api.Admin.SetUserTrustResponseData> => {
+  const res = await xhr.post<Api.Admin.SetUserTrustResponseData>(`/admin/api/users/${id}/_reset_trust`, {
+    headers: JSON_HEADERS,
+  })
+  return await res.json()
+}
+
+const recomputeTrust = async (): Promise<Api.Admin.RecomputeTrustResponseData> => {
+  const res = await xhr.post<Api.Admin.RecomputeTrustResponseData>('/admin/api/uploaders/_recompute_trust', {
+    headers: JSON_HEADERS,
+  })
+  return await res.json()
+}
+
 export default {
   getAnnouncements,
   postAnnouncement,
@@ -209,6 +262,7 @@ export default {
   saveFeatured,
   saveFeaturedTeasers,
   getImages,
+  getPendingImages,
   getImage,
   deleteImage,
   setImagePrivate,
@@ -218,4 +272,9 @@ export default {
   getServerInfo,
   mergeClientIdsIntoUser,
   fixPieces,
+  getUploaders,
+  trustUser,
+  untrustUser,
+  resetUserTrust,
+  recomputeTrust,
 }

--- a/frontend/src/admin/components/Nav.vue
+++ b/frontend/src/admin/components/Nav.vue
@@ -13,6 +13,12 @@
       Images
     </v-btn>
     <v-btn
+      :to="{name: 'admin_approvals'}"
+      prepend-icon="mdi-check-decagram"
+    >
+      Approvals
+    </v-btn>
+    <v-btn
       :to="{name: 'admin_users'}"
       prepend-icon="mdi-account"
     >
@@ -23,6 +29,12 @@
       prepend-icon="mdi-account-group"
     >
       Groups
+    </v-btn>
+    <v-btn
+      :to="{name: 'admin_uploaders'}"
+      prepend-icon="mdi-upload"
+    >
+      Uploaders
     </v-btn>
     <v-btn
       :to="{name: 'admin_announcements'}"

--- a/frontend/src/admin/views/ApprovalsView.vue
+++ b/frontend/src/admin/views/ApprovalsView.vue
@@ -1,0 +1,202 @@
+<template>
+  <v-container>
+    <Nav />
+    <h1>Approvals</h1>
+    <p class="text-disabled mb-2">
+      Public images pending approval (oldest first). {{ pendingCount }} pending.
+    </p>
+
+    <Pagination
+      v-if="images"
+      :pagination="images.pagination"
+      @click="onPagination"
+    />
+    <div
+      v-if="images && images.items.length === 0"
+      class="text-h6 my-4"
+    >
+      🎉 No images pending approval!
+    </div>
+    <v-table
+      v-if="images && images.items.length > 0"
+      density="compact"
+    >
+      <thead>
+        <tr>
+          <th>Preview</th>
+          <th>Infos</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="item in images.items"
+          :key="item.id"
+        >
+          <td>
+            <a
+              :href="`/uploads/${item.filename}`"
+              target="_blank"
+              class="image-holder"
+            ><img
+              :src="resizeUrl(`/image-service/image/${item.filename}`, 500, 350, 'contain')"
+              class="image"
+            ></a>
+          </td>
+          <td>
+            <div class="d-flex ga-3">
+              <span class="text-disabled">Title:</span> {{ item.title || '-' }}
+              <span class="text-disabled">Dimensions:</span> {{ item.width }}×{{ item.height }}
+              <span class="text-disabled">NSFW:</span> {{ item.nsfw ? '😳 NSFW' : '-' }}
+            </div>
+            <div class="d-flex ga-3">
+              <span class="text-disabled">Id:</span> {{ item.id }}
+              <span class="text-disabled">Uploader:</span> {{ item.uploader_user_name || item.uploader_user_id || '-' }}
+              <span class="text-disabled">Created:</span> {{ item.created }}
+            </div>
+            <div class="d-flex ga-3">
+              <span class="text-disabled">Copyright:</span> {{ item.copyright_name || '-' }}
+              <template v-if="item.copyright_url">
+                (<a
+                  :href="item.copyright_url"
+                  target="_blank"
+                >{{ item.copyright_url }}</a>)
+              </template>
+            </div>
+          </td>
+          <td>
+            <div class="d-flex ga-1">
+              <v-btn
+                size="small"
+                color="green"
+                @click="onApprove(item)"
+              >
+                APPROVE
+              </v-btn>
+              <v-btn
+                size="small"
+                color="red"
+                @click="onReject(item)"
+              >
+                REJECT
+              </v-btn>
+              <v-btn
+                size="small"
+                @click="onSetPrivate(item)"
+              >
+                SET PRIVATE
+              </v-btn>
+              <v-btn
+                size="small"
+                color="error"
+                variant="outlined"
+                @click="onDelete(item)"
+              >
+                DELETE
+              </v-btn>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </v-table>
+    <Pagination
+      v-if="images"
+      :pagination="images.pagination"
+      @click="onPagination"
+    />
+  </v-container>
+</template>
+<script setup lang="ts">
+import { onUnmounted, onMounted, ref, computed } from 'vue'
+import { resizeUrl } from '@common/ImageService'
+import { me, onLoginStateChange } from '../../user'
+import api from '../../_api'
+import Nav from '../components/Nav.vue'
+import Pagination from '../../components/Pagination.vue'
+import type { ImageRowWithCount, Pagination as PaginationType } from '@common/Types'
+
+const perPage = 50
+const images = ref<{ items: ImageRowWithCount[], pagination: PaginationType } | null>(null)
+
+const pendingCount = computed(() => images.value?.pagination.total ?? 0)
+
+const removeItem = (item: ImageRowWithCount) => {
+  if (images.value) {
+    images.value.items = images.value.items.filter(i => i.id !== item.id)
+    images.value.pagination.total--
+  }
+}
+
+const onApprove = async (image: ImageRowWithCount) => {
+  const resp = await api.admin.approveImage(image.id)
+  if ('error' in resp || !resp.ok) {
+    alert('Approving image failed!')
+  } else {
+    removeItem(image)
+  }
+}
+
+const onReject = async (image: ImageRowWithCount) => {
+  const reason = prompt('Rejection reason (optional):') ?? ''
+  const resp = await api.admin.rejectImage(image.id, reason)
+  if ('error' in resp || !resp.ok) {
+    alert('Rejecting image failed!')
+  } else {
+    removeItem(image)
+  }
+}
+
+const onSetPrivate = async (image: ImageRowWithCount) => {
+  if (!confirm(`Set image ${image.id} as private? This cannot be undone!`)) {
+    return
+  }
+  const resp = await api.admin.setImagePrivate(image.id)
+  if ('error' in resp || !resp.ok) {
+    alert('Setting image to private failed!')
+  } else {
+    removeItem(image)
+  }
+}
+
+const onDelete = async (image: ImageRowWithCount) => {
+  if (!confirm(`Really delete image ${image.id}?`)) {
+    return
+  }
+  const resp = await api.admin.deleteImage(image.id)
+  if ('error' in resp || !resp.ok) {
+    alert('Deleting image failed!')
+  } else {
+    removeItem(image)
+  }
+}
+
+const loadImages = async (data: { limit: number, offset: number }) => {
+  const responseData = await api.admin.getPendingImages(data)
+  if ('error' in responseData) {
+    console.error('Error loading pending images:', responseData.error)
+    return null
+  }
+  return responseData
+}
+
+const onPagination = async (q: { limit: number, offset: number }) => {
+  if (!images.value) {
+    return
+  }
+  images.value = await loadImages(q)
+}
+
+const onInit = async () => {
+  images.value = me.value ? await loadImages({ limit: perPage, offset: 0 }) : null
+}
+
+let offLoginStateChange: () => void = () => {}
+onMounted(async () => {
+  await onInit()
+  offLoginStateChange = onLoginStateChange(onInit)
+})
+
+onUnmounted(() => {
+  offLoginStateChange()
+})
+</script>

--- a/frontend/src/admin/views/ImagesView.vue
+++ b/frontend/src/admin/views/ImagesView.vue
@@ -42,6 +42,9 @@
               <span class="text-disabled">Private:</span> <span :class="{ 'color-private': item.private }">{{ item.private ? '✓' : '✖' }}</span>
               <span class="text-disabled">NSFW:</span> {{ item.nsfw ? '😳 NSFW' : '-' }}
               <span class="text-disabled">State:</span> <code :class="`state-${item.state}`">{{ item.state }}</code>
+              <template v-if="item.state === 'rejected' && item.reject_reason">
+                <span class="text-disabled">Reason:</span> <span :title="item.reject_reason">{{ item.reject_reason.length > 50 ? item.reject_reason.substring(0, 50) + '…' : item.reject_reason }}</span>
+              </template>
             </div>
             <div class="d-flex ga-3">
               <span class="text-disabled">Id:</span> {{ item.id }}
@@ -159,7 +162,8 @@ const onApprove = async (image: ImageRowWithCount) => {
 }
 
 const onReject = async (image: ImageRowWithCount) => {
-  const resp = await api.admin.rejectImage(image.id)
+  const reason = prompt('Rejection reason (optional):') ?? ''
+  const resp = await api.admin.rejectImage(image.id, reason)
   if ('error' in resp || !resp.ok) {
     alert('Rejecting image failed!')
   } else {

--- a/frontend/src/admin/views/UploadersView.vue
+++ b/frontend/src/admin/views/UploadersView.vue
@@ -1,0 +1,307 @@
+<template>
+  <v-container>
+    <Nav />
+    <h1>Uploaders</h1>
+
+    <div class="mb-4">
+      <v-btn
+        color="primary"
+        :disabled="recomputingTrust"
+        @click="onRecomputeTrust"
+      >
+        Recompute Trust for All Uploaders
+      </v-btn>
+      <span
+        v-if="recomputeResult"
+        class="ml-3"
+      >{{ recomputeResult }}</span>
+    </div>
+
+    <Pagination
+      v-if="uploaders"
+      :pagination="uploaders.pagination"
+      @click="onPagination"
+    />
+    <v-table
+      v-if="uploaders"
+      density="compact"
+    >
+      <thead>
+        <tr>
+          <th />
+          <th>User Id</th>
+          <th>Name</th>
+          <th>Trusted</th>
+          <th>Approved</th>
+          <th>Rejected</th>
+          <th>Pending</th>
+          <th>Total</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <template
+          v-for="item in uploaders.items"
+          :key="item.id"
+        >
+          <tr>
+            <td>
+              <v-btn
+                size="x-small"
+                variant="text"
+                :icon="expandedUsers[item.id] ? 'mdi-chevron-up' : 'mdi-chevron-down'"
+                @click="toggleExpand(item)"
+              />
+            </td>
+            <td>{{ item.id }}</td>
+            <td>{{ item.name || '-' }}</td>
+            <td>
+              <span :class="item.trusted ? 'trusted-yes' : 'trusted-no'">
+                {{ item.trusted ? '✓ Trusted' : '✖ Not trusted' }}
+              </span>
+              <span
+                v-if="item.trustManuallySet"
+                class="text-caption ml-1"
+                title="Manually set by admin — won't be changed by automatic recomputation"
+              >(manual)</span>
+            </td>
+            <td>{{ item.approvedCount }}</td>
+            <td>{{ item.rejectedCount }}</td>
+            <td>{{ item.pendingCount }}</td>
+            <td>{{ item.totalCount }}</td>
+            <td>
+              <div class="d-flex ga-1">
+                <v-btn
+                  v-if="!item.trusted"
+                  size="x-small"
+                  color="green"
+                  @click="onTrust(item)"
+                >
+                  TRUST
+                </v-btn>
+                <v-btn
+                  v-else
+                  size="x-small"
+                  color="red"
+                  @click="onUntrust(item)"
+                >
+                  UNTRUST
+                </v-btn>
+                <v-btn
+                  v-if="item.trustManuallySet"
+                  size="x-small"
+                  variant="outlined"
+                  @click="onResetTrust(item)"
+                >
+                  RESET TO AUTO
+                </v-btn>
+              </div>
+            </td>
+          </tr>
+          <tr v-if="expandedUsers[item.id]">
+            <td
+              colspan="9"
+              class="pa-3"
+            >
+              <div
+                v-if="!userImages[item.id]"
+                class="text-disabled"
+              >
+                Loading...
+              </div>
+              <div
+                v-else-if="userImages[item.id].length === 0"
+                class="text-disabled"
+              >
+                No images found.
+              </div>
+              <div
+                v-else
+                class="d-flex flex-wrap ga-2"
+              >
+                <div
+                  v-for="img in userImages[item.id]"
+                  :key="img.id"
+                  class="image-thumb"
+                >
+                  <a
+                    :href="`/uploads/${img.filename}`"
+                    target="_blank"
+                  >
+                    <img
+                      :src="resizeUrl(`/image-service/image/${img.filename}`, 100, 70, 'contain')"
+                      :title="`${img.title || img.filename} [${img.state}]${img.state === 'rejected' && img.reject_reason ? ' - ' + img.reject_reason : ''}`"
+                      :class="`thumb-${img.state}`"
+                    >
+                  </a>
+                  <div class="text-caption">
+                    <code :class="`state-${img.state}`">{{ img.state }}</code>
+                  </div>
+                </div>
+              </div>
+            </td>
+          </tr>
+        </template>
+      </tbody>
+    </v-table>
+    <Pagination
+      v-if="uploaders"
+      :pagination="uploaders.pagination"
+      @click="onPagination"
+    />
+  </v-container>
+</template>
+<script setup lang="ts">
+import { onUnmounted, onMounted, ref, reactive } from 'vue'
+import { resizeUrl } from '@common/ImageService'
+import { me, onLoginStateChange } from '../../user'
+import api from '../../_api'
+import Nav from '../components/Nav.vue'
+import Pagination from '../../components/Pagination.vue'
+import type { ImageRowWithCount, Pagination as PaginationType, UploaderInfo, UserId } from '@common/Types'
+
+const perPage = 50
+const uploaders = ref<{ items: UploaderInfo[], pagination: PaginationType } | null>(null)
+const recomputingTrust = ref(false)
+const recomputeResult = ref('')
+const expandedUsers = reactive<Record<number, boolean>>({})
+const userImages = reactive<Record<number, ImageRowWithCount[]>>({})
+
+const toggleExpand = async (item: UploaderInfo) => {
+  const id = item.id as number
+  if (expandedUsers[id]) {
+    expandedUsers[id] = false
+    return
+  }
+  expandedUsers[id] = true
+  if (!userImages[id]) {
+    const resp = await api.admin.getImages({ limit: 100, offset: 0, uploaderUserId: item.id })
+    if ('error' in resp) {
+      userImages[id] = []
+    } else {
+      userImages[id] = resp.items
+    }
+  }
+}
+
+const onRecomputeTrust = async () => {
+  if (!confirm('Recompute trust status for all uploaders based on their approval history?')) {
+    return
+  }
+  recomputingTrust.value = true
+  recomputeResult.value = ''
+  const resp = await api.admin.recomputeTrust()
+  recomputingTrust.value = false
+  if ('error' in resp) {
+    recomputeResult.value = `Error: ${resp.error}`
+  } else {
+    recomputeResult.value = `Done! Recomputed trust for ${resp.count} uploaders.`
+    // Reload the list to reflect changes
+    uploaders.value = await loadUploaders({ limit: perPage, offset: 0 })
+  }
+}
+
+const onTrust = async (item: UploaderInfo) => {
+  const resp = await api.admin.trustUser(item.id)
+  if ('error' in resp || !resp.ok) {
+    alert('Trusting user failed!')
+  } else {
+    item.trusted = 1
+    item.trustManuallySet = 1
+  }
+}
+
+const onUntrust = async (item: UploaderInfo) => {
+  const resp = await api.admin.untrustUser(item.id)
+  if ('error' in resp || !resp.ok) {
+    alert('Untrusting user failed!')
+  } else {
+    item.trusted = 0
+    item.trustManuallySet = 1
+  }
+}
+
+const onResetTrust = async (item: UploaderInfo) => {
+  const resp = await api.admin.resetUserTrust(item.id)
+  if ('error' in resp || !resp.ok) {
+    alert('Resetting trust failed!')
+  } else {
+    item.trustManuallySet = 0
+    // Reload to get the recomputed trust value
+    const data = uploaders.value ? await loadUploaders({
+      limit: perPage,
+      offset: uploaders.value.pagination.offset,
+    }) : null
+    if (data) {
+      uploaders.value = data
+    }
+  }
+}
+
+const loadUploaders = async (data: { limit: number, offset: number }) => {
+  const responseData = await api.admin.getUploaders(data)
+  if ('error' in responseData) {
+    console.error('Error loading uploaders:', responseData.error)
+    return null
+  }
+  return responseData
+}
+
+const onPagination = async (q: { limit: number, offset: number }) => {
+  if (!uploaders.value) {
+    return
+  }
+  uploaders.value = await loadUploaders(q)
+}
+
+const onInit = async () => {
+  uploaders.value = me.value ? await loadUploaders({ limit: perPage, offset: 0 }) : null
+}
+
+let offLoginStateChange: () => void = () => {}
+onMounted(async () => {
+  await onInit()
+  offLoginStateChange = onLoginStateChange(onInit)
+})
+
+onUnmounted(() => {
+  offLoginStateChange()
+})
+</script>
+<style scss scoped>
+.trusted-yes {
+  color: green;
+  font-weight: bold;
+}
+.trusted-no {
+  color: grey;
+}
+.image-thumb {
+  text-align: center;
+}
+.image-thumb img {
+  border: 2px solid transparent;
+  border-radius: 4px;
+}
+.thumb-approved img,
+img.thumb-approved {
+  border-color: green;
+}
+.thumb-rejected img,
+img.thumb-rejected {
+  border-color: red;
+}
+.thumb-pending_approval img,
+img.thumb-pending_approval {
+  border-color: orange;
+}
+.state-approved {
+  color: green;
+}
+.state-rejected {
+  color: red;
+}
+.state-pending_approval {
+  color: orange;
+}
+</style>

--- a/frontend/src/components/teasers/FinishedGameTeaser.vue
+++ b/frontend/src/components/teasers/FinishedGameTeaser.vue
@@ -25,6 +25,7 @@
       <div
         v-if="stateInfo"
         :class="['game-teaser-info', stateInfo.class]"
+        :title="stateInfo.title"
       >
         <v-icon :icon="stateInfo.icon" /> {{ stateInfo.text }}
       </div>
@@ -133,7 +134,7 @@ const time = (start: number, end: number) => {
   return `${timeDiffStr}`
 }
 
-const stateInfo = computed<null | { class: string; text: string; icon: string }>(() => {
+const stateInfo = computed<null | { class: string; text: string; title?: string; icon: string }>(() => {
   if (props.game.isPrivate) {
     return {
       class: 'game-is-private-info',
@@ -161,6 +162,7 @@ const stateInfo = computed<null | { class: string; text: string; icon: string }>
     return {
       class: 'image-is-rejected-info',
       text: 'Image rejected',
+      title: props.game.image.rejectReason || '',
       icon: 'mdi-cancel',
     }
   }

--- a/frontend/src/components/teasers/ImageTeaser.vue
+++ b/frontend/src/components/teasers/ImageTeaser.vue
@@ -20,6 +20,7 @@
         <div
           v-if="imageStateInfo"
           :class="`imageteaser-info ${imageStateInfo.class}`"
+          :title="imageStateInfo.title"
         >
           <v-icon :icon="imageStateInfo.icon" /> {{ imageStateInfo.text }}
         </div>
@@ -139,7 +140,7 @@ const canEdit = computed((): boolean => {
   return me.value.id === props.image.uploaderUserId
 })
 
-const imageStateInfo = computed((): { class: string, text: string, icon: string } | null => {
+const imageStateInfo = computed((): { class: string, text: string, title?: string, icon: string } | null => {
   if (props.image.private) {
     return {
       class: 'image-is-private-info',
@@ -160,6 +161,7 @@ const imageStateInfo = computed((): { class: string, text: string, icon: string 
     return {
       class: 'image-is-rejected-info',
       text: 'Image rejected',
+      title: props.image.rejectReason || '',
       icon: 'mdi-close-circle-outline',
     }
   }

--- a/frontend/src/components/teasers/RunningGameTeaser.vue
+++ b/frontend/src/components/teasers/RunningGameTeaser.vue
@@ -26,6 +26,7 @@
         <div
           v-if="stateInfo"
           :class="['game-teaser-banderole', stateInfo.class]"
+          :title="stateInfo.title"
         >
           <v-icon :icon="stateInfo.icon" /> {{ stateInfo.text }}
         </div>
@@ -158,7 +159,7 @@ const time = ((start: number, end: number) => {
 
 const canDelete = computed<boolean>(() => !!(me.value && me.value.id === props.game.creatorUserId))
 
-const stateInfo = computed<null | { class: string; text: string; icon: string }>(() => {
+const stateInfo = computed<null | { class: string; text: string; title?: string; icon: string }>(() => {
   if (props.game.isPrivate) {
     return {
       class: 'game-is-private-info',
@@ -186,6 +187,7 @@ const stateInfo = computed<null | { class: string; text: string; icon: string }>
     return {
       class: 'image-is-rejected-info',
       text: 'Image rejected',
+      title: props.game.image.rejectReason || '',
       icon: 'mdi-cancel',
     }
   }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -24,6 +24,8 @@ import AdminGroups from './admin/views/GroupsView.vue'
 import AdminAnnouncements from './admin/views/AnnouncementsView.vue'
 import AdminFeatured from './admin/views/FeaturedView.vue'
 import AdminFeaturedEdit from './admin/views/FeaturedEditView.vue'
+import AdminUploaders from './admin/views/UploadersView.vue'
+import AdminApprovals from './admin/views/ApprovalsView.vue'
 import debug from './debug'
 import api from './_api'
 import config from './config'
@@ -77,7 +79,9 @@ const run = async () => {
       { name: 'admin_games', path: '/admin/games', component: AdminGames, meta: { admin: true, title: 'Admin - Games' } },
       { name: 'admin_users', path: '/admin/users', component: AdminUsers, meta: { admin: true, title: 'Admin - Users' } },
       { name: 'admin_images', path: '/admin/images', component: AdminImages, meta: { admin: true, title: 'Admin - Images' } },
+      { name: 'admin_approvals', path: '/admin/approvals', component: AdminApprovals, meta: { admin: true, title: 'Admin - Approvals' } },
       { name: 'admin_groups', path: '/admin/groups', component: AdminGroups, meta: { admin: true, title: 'Admin - Groups' } },
+      { name: 'admin_uploaders', path: '/admin/uploaders', component: AdminUploaders, meta: { admin: true, title: 'Admin - Uploaders' } },
       { name: 'admin_announcements', path: '/admin/announcements', component: AdminAnnouncements, meta: { admin: true, title: 'Admin - Announcements' } },
       { name: 'admin_featured', path: '/admin/featured', component: AdminFeatured, meta: { admin: true, title: 'Admin - Featured' } },
       { name: 'admin_featured_edit', path: '/admin/featured/:id', component: AdminFeaturedEdit, meta: { admin: true, title: 'Admin - Featured - Edit' } },

--- a/server/src/Config.ts
+++ b/server/src/Config.ts
@@ -54,6 +54,9 @@ export interface Config {
   canny: CannyConfig
   mail: MailConfig
   discord: DiscordConfig
+  trust?: {
+    threshold: number
+  }
 }
 
 const init = (): Config => {

--- a/server/src/GameService.test.ts
+++ b/server/src/GameService.test.ts
@@ -57,6 +57,7 @@ describe('GameService', () => {
         reported: 0,
         nsfw: false,
         state: 'approved',
+        rejectReason: '',
       }
 
       const mockGameRow: GameRow = {
@@ -142,6 +143,7 @@ describe('GameService', () => {
         reported: 0,
         nsfw: false,
         state: 'approved',
+        rejectReason: '',
       }
 
       // Create a reference puzzle using the correct seed (gameId + gameStartedTime)

--- a/server/src/Images.ts
+++ b/server/src/Images.ts
@@ -65,6 +65,7 @@ export class Images {
       reported: row.reported,
       nsfw: !!row.nsfw,
       state: row.state,
+      rejectReason: row.reject_reason,
     }
   }
 

--- a/server/src/Users.ts
+++ b/server/src/Users.ts
@@ -123,6 +123,8 @@ export class Users {
         created: new Date(),
         name: '',
         email: '',
+        trusted: 0,
+        trust_manually_set: 0,
       })
       data = { token: null, user, user_type: 'guest' }
     }

--- a/server/src/repo/ImagesRepo.ts
+++ b/server/src/repo/ImagesRepo.ts
@@ -1,5 +1,5 @@
 import { ImageSearchSort } from '@common/Types'
-import type { ImageId, ImageRow, ImageRowWithCount, ImageXTagRow, TagId, TagRow, TagRowWithCount, UserId } from '@common/Types'
+import type { ImageId, ImageRow, ImageRowWithCount, ImageXTagRow, Pagination, TagId, TagRow, TagRowWithCount, UploaderInfo, UserId } from '@common/Types'
 import type Db from '../lib/Db'
 import type { OrderBy, WhereRaw } from '../lib/Db'
 import DbData from '../app/DbData'
@@ -43,6 +43,7 @@ export class ImagesRepo {
     filter: {
       ids: ImageId[]
       tags: string[]
+      uploaderUserId?: UserId
     }
   }): Promise<ImageRowWithCount[]> {
     const { offset, limit, filter } = args
@@ -59,6 +60,10 @@ export class ImagesRepo {
 
     if (filter.ids.length > 0) {
       rawWhere['i.id'] = { '$in': filter.ids }
+    }
+
+    if (filter.uploaderUserId) {
+      rawWhere['i.uploader_user_id'] = filter.uploaderUserId
     }
 
     const where = this.db._buildWhere(rawWhere)
@@ -87,6 +92,35 @@ export class ImagesRepo {
 
   async delete(imageId: ImageId): Promise<void> {
     await this.db.delete(DbData.Tables.Images, { id: imageId })
+  }
+
+  async getPendingApprovals(offset: number, limit: number): Promise<{ items: ImageRowWithCount[], total: number }> {
+    const countRow = await this.db._get<{ count: number }>(`
+      SELECT COUNT(*)::int AS count
+      FROM ${DbData.Tables.Images}
+      WHERE state = 'pending_approval' AND private = 0
+    `)
+    const total = countRow?.count ?? 0
+
+    const items = await this.db._getMany<ImageRowWithCount>(`
+      WITH counts AS (
+        SELECT COUNT(*)::int AS count, image_id
+        FROM ${DbData.Tables.Games}
+        GROUP BY image_id
+      )
+      SELECT
+        i.*,
+        COALESCE(counts.count, 0) AS games_count,
+        COALESCE(u.name, '') AS uploader_user_name
+      FROM ${DbData.Tables.Images} i
+        LEFT JOIN counts ON counts.image_id = i.id
+        LEFT JOIN ${DbData.Tables.Users} u ON u.id = i.uploader_user_id
+      WHERE i.state = 'pending_approval' AND i.private = 0
+      ORDER BY i.created ASC
+      ${this.db._buildLimit({ offset, limit })}
+    `, [])
+
+    return { items, total }
   }
 
   async insert(image: Omit<ImageRow, 'id'>): Promise<ImageId> {
@@ -304,5 +338,45 @@ export class ImagesRepo {
 
   async reportImage(imageId: ImageId): Promise<void> {
     await this.db.run(`UPDATE ${DbData.Tables.Images} SET reported = reported + 1 WHERE id = $1`, [imageId])
+  }
+
+  async getUploadersWithStats(
+    offset: number,
+    limit: number,
+  ): Promise<{ items: UploaderInfo[], pagination: Pagination }> {
+    const countRow = await this.db._get<{ count: number }>(`
+      SELECT COUNT(DISTINCT uploader_user_id)::int AS count
+      FROM ${DbData.Tables.Images}
+      WHERE uploader_user_id IS NOT NULL
+    `)
+    const total = countRow?.count ?? 0
+
+    const items = await this.db._getMany<UploaderInfo>(`
+      SELECT
+        u.id,
+        u.name,
+        u.trusted,
+        u.trust_manually_set AS "trustManuallySet",
+        COUNT(*) FILTER (WHERE i.state = 'approved')::int AS "approvedCount",
+        COUNT(*) FILTER (WHERE i.state = 'rejected')::int AS "rejectedCount",
+        COUNT(*) FILTER (WHERE i.state = 'pending_approval')::int AS "pendingCount",
+        COUNT(*)::int AS "totalCount"
+      FROM ${DbData.Tables.Users} u
+      INNER JOIN ${DbData.Tables.Images} i ON i.uploader_user_id = u.id
+      GROUP BY u.id
+      ORDER BY u.id DESC
+      OFFSET $1 LIMIT $2
+    `, [offset, limit])
+
+    return { items, pagination: { total, offset, limit } }
+  }
+
+  async getAllUploaderIds(): Promise<UserId[]> {
+    const rows = await this.db._getMany<{ uploader_user_id: UserId }>(`
+      SELECT DISTINCT uploader_user_id
+      FROM ${DbData.Tables.Images}
+      WHERE uploader_user_id IS NOT NULL
+    `)
+    return rows.map(r => r.uploader_user_id)
   }
 }

--- a/server/src/repo/UsersRepo.ts
+++ b/server/src/repo/UsersRepo.ts
@@ -179,4 +179,43 @@ export class UsersRepo {
   async getUserGroups(): Promise<UserGroupRow[]> {
     return await this.db.getMany(DbData.Tables.UserGroups, undefined, [{ id: -1 }])
   }
+
+  async isUserTrusted(userId: UserId): Promise<boolean> {
+    const user = await this.get({ id: userId })
+    return user?.trusted === 1
+  }
+
+  async recomputeTrust(userId: UserId, threshold: number): Promise<void> {
+    const user = await this.get({ id: userId })
+    if (user?.trust_manually_set) {
+      return
+    }
+
+    const row = await this.db._get<{ approved_count: number, rejected_count: number, pending_public_count: number }>(`
+      SELECT
+        COUNT(*) FILTER (WHERE state = 'approved')::int AS approved_count,
+        COUNT(*) FILTER (WHERE state = 'rejected')::int AS rejected_count,
+        COUNT(*) FILTER (WHERE state = 'pending_approval' AND private = 0)::int AS pending_public_count
+      FROM ${DbData.Tables.Images}
+      WHERE uploader_user_id = $1
+    `, [userId])
+
+    const approvedCount = row?.approved_count ?? 0
+    const rejectedCount = row?.rejected_count ?? 0
+    const pendingPublicCount = row?.pending_public_count ?? 0
+    const requiredApprovals = threshold * (1 + rejectedCount)
+    const trusted = (pendingPublicCount === 0 && approvedCount >= requiredApprovals) ? 1 : 0
+    await this.db.update(DbData.Tables.Users, { trusted }, { id: userId })
+  }
+
+  async setTrusted(userId: UserId, trusted: boolean): Promise<void> {
+    await this.db.update(DbData.Tables.Users, {
+      trusted: trusted ? 1 : 0,
+      trust_manually_set: 1,
+    }, { id: userId })
+  }
+
+  async resetTrustToAuto(userId: UserId): Promise<void> {
+    await this.db.update(DbData.Tables.Users, { trust_manually_set: 0 }, { id: userId })
+  }
 }

--- a/server/src/web_routes/admin/api/index.ts
+++ b/server/src/web_routes/admin/api/index.ts
@@ -4,9 +4,10 @@ import type { Server } from '../../../Server'
 import { MergeClientIdsIntoUser } from '../../../admin-tools/MergeClientIdsIntoUser'
 import GameLog from '../../../GameLog'
 import { FixPieces } from '../../../admin-tools/FixPieces'
-import type { Api, FeaturedId, FeaturedTeaserRow, GameId, ImageId, ServerInfo } from '@common/Types'
+import type { Api, FeaturedId, FeaturedTeaserRow, GameId, ImageId, ServerInfo, UserId } from '@common/Types'
 import { newJSONDateString } from '@common/Util'
 import GameCommon from '@common/GameCommon'
+import config from '../../../Config'
 
 export default function createRouter(
   server: Server,
@@ -86,6 +87,20 @@ export default function createRouter(
     res.send(responseData)
   })
 
+  router.get('/images/pending', async (req, res) => {
+    try {
+      const { offset, limit } = getPaginationParams(req)
+      const { items, total } = await server.repos.images.getPendingApprovals(offset, limit)
+      const responseData: Api.Admin.GetImagesResponseData = {
+        items,
+        pagination: { total, offset, limit },
+      }
+      res.send(responseData)
+    } catch (error) {
+      res.status(400).send(createErrorResponseData(error))
+    }
+  })
+
   router.get('/images', async (req, res) => {
     try {
       const { offset, limit } = getPaginationParams(req)
@@ -103,14 +118,18 @@ export default function createRouter(
         tags = tagsCsv.split(',').map(tag => tag.trim())
       }
 
+      const uploaderUserIdRaw = req.query.uploaderUserId ? parseInt(String(req.query.uploaderUserId), 10) : undefined
+      const uploaderUserId = uploaderUserIdRaw && !isNaN(uploaderUserIdRaw) ? uploaderUserIdRaw as UserId : undefined
+
       const total = await server.repos.images.count()
+      const filter: { ids: ImageId[], tags: string[], uploaderUserId?: UserId } = { ids, tags }
+      if (uploaderUserId) {
+        filter.uploaderUserId = uploaderUserId
+      }
       const items = await server.repos.images.getWithGameCount({
         offset,
         limit,
-        filter: {
-          ids,
-          tags,
-        },
+        filter,
       })
       const responseData: Api.Admin.GetImagesResponseData = {
         items,
@@ -209,6 +228,9 @@ export default function createRouter(
     // delete from storage
     await server.images.deleteImagesFromStorage(image.filename)
 
+    const threshold = config.trust?.threshold ?? 5
+    await server.repos.users.recomputeTrust(image.uploader_user_id, threshold)
+
     const responseData: Api.Admin.DeleteImageResponseData = { ok: true }
     res.send(responseData)
   })
@@ -246,6 +268,9 @@ export default function createRouter(
       // update leaderboards, as private games are excluded there they may have changed
       await server.repos.leaderboard.updateLeaderboards()
 
+      const threshold = config.trust?.threshold ?? 5
+      await server.repos.users.recomputeTrust(image.uploader_user_id, threshold)
+
       const responseData: Api.Admin.SetImagePrivateResponseData = { ok: true }
       res.send(responseData)
     } catch (error) {
@@ -268,6 +293,9 @@ export default function createRouter(
         { id },
       )
 
+      const threshold = config.trust?.threshold ?? 5
+      await server.repos.users.recomputeTrust(image.uploader_user_id, threshold)
+
       const responseData: Api.Admin.ApproveImageResponseData = { ok: true }
       res.send(responseData)
     } catch (error) {
@@ -275,7 +303,7 @@ export default function createRouter(
     }
   })
 
-  router.post('/images/:id/_reject', async (req, res) => {
+  router.post('/images/:id/_reject', express.json(), async (req, res) => {
     try {
       const id = parseInt(req.params.id, 10) as ImageId
       const image = await server.repos.images.get({ id })
@@ -285,10 +313,14 @@ export default function createRouter(
         return
       }
 
+      const rejectReason = req.body?.reason || ''
       await server.repos.images.update(
-        { state: 'rejected' },
+        { state: 'rejected', reject_reason: rejectReason },
         { id },
       )
+
+      const threshold = config.trust?.threshold ?? 5
+      await server.repos.users.recomputeTrust(image.uploader_user_id, threshold)
 
       const responseData: Api.Admin.RejectImageResponseData = { ok: true }
       res.send(responseData)
@@ -374,6 +406,66 @@ export default function createRouter(
     void server.discord.announce(`**${title}**\n${announcement.message}`)
     const responseData: Api.Admin.PostAnnouncementsResponseData = { announcement }
     res.send(responseData)
+  })
+
+  router.get('/uploaders', async (req, res) => {
+    try {
+      const { offset, limit } = getPaginationParams(req)
+      const result = await server.repos.images.getUploadersWithStats(offset, limit)
+      const responseData: Api.Admin.GetUploadersResponseData = result
+      res.send(responseData)
+    } catch (error) {
+      res.status(400).send(createErrorResponseData(error))
+    }
+  })
+
+  router.post('/users/:id/_trust', async (req, res) => {
+    try {
+      const id = parseInt(req.params.id, 10) as UserId
+      await server.repos.users.setTrusted(id, true)
+      const responseData: Api.Admin.SetUserTrustResponseData = { ok: true }
+      res.send(responseData)
+    } catch (error) {
+      res.status(400).send(createErrorResponseData(error))
+    }
+  })
+
+  router.post('/users/:id/_untrust', async (req, res) => {
+    try {
+      const id = parseInt(req.params.id, 10) as UserId
+      await server.repos.users.setTrusted(id, false)
+      const responseData: Api.Admin.SetUserTrustResponseData = { ok: true }
+      res.send(responseData)
+    } catch (error) {
+      res.status(400).send(createErrorResponseData(error))
+    }
+  })
+
+  router.post('/users/:id/_reset_trust', async (req, res) => {
+    try {
+      const id = parseInt(req.params.id, 10) as UserId
+      await server.repos.users.resetTrustToAuto(id)
+      const threshold = config.trust?.threshold ?? 5
+      await server.repos.users.recomputeTrust(id, threshold)
+      const responseData: Api.Admin.SetUserTrustResponseData = { ok: true }
+      res.send(responseData)
+    } catch (error) {
+      res.status(400).send(createErrorResponseData(error))
+    }
+  })
+
+  router.post('/uploaders/_recompute_trust', async (_req, res) => {
+    try {
+      const threshold = config.trust?.threshold ?? 5
+      const uploaderIds = await server.repos.images.getAllUploaderIds()
+      for (const uploaderId of uploaderIds) {
+        await server.repos.users.recomputeTrust(uploaderId, threshold)
+      }
+      const responseData: Api.Admin.RecomputeTrustResponseData = { ok: true, count: uploaderIds.length }
+      res.send(responseData)
+    } catch (error) {
+      res.status(400).send(createErrorResponseData(error))
+    }
   })
 
   return router

--- a/server/src/web_routes/api/index.ts
+++ b/server/src/web_routes/api/index.ts
@@ -178,6 +178,8 @@ export default function createRouter(
           created: new Date(),
           email: provider_email,
           name: userData.data[0].display_name,
+          trusted: 0,
+          trust_manually_set: 0,
         })
       } else {
         let updateNeeded = false
@@ -374,6 +376,8 @@ export default function createRouter(
         created: newJSONDateString(),
         email: emailRaw,
         name: usernameRaw,
+        trusted: 0,
+        trust_manually_set: 0,
       })
     }
 
@@ -708,6 +712,7 @@ export default function createRouter(
       // post form, so booleans are submitted as 'true' | 'false'
       const isPrivate = req.body.isPrivate === 'false' ? false : true
       const isNsfw = req.body.isNsfw === 'true' ? true : false
+      const isTrusted = await server.repos.users.isUserTrusted(user.id)
       const imageId = await im.insertImage({
         uploader_user_id: user.id,
         filename: req.file.filename,
@@ -722,7 +727,8 @@ export default function createRouter(
         reported: 0,
         nsfw: isNsfw ? 1 : 0,
         checksum,
-        state: 'pending_approval',
+        state: isTrusted ? 'approved' : 'pending_approval',
+        reject_reason: '',
       })
 
       if (req.body.tags) {


### PR DESCRIPTION
Add a trust system so proven uploaders get their images auto-approved
instead of waiting for manual admin review.

- Add `users.trusted`, `users.trust_manually_set`, and
  `images.reject_reason` columns (DB patch 26)
- Auto-approve uploads from trusted users; others stay pending
- Trust is computed from approval history: requires
  `threshold × (1 + rejections)` approved images and zero pending
  public images (default threshold: 5, configurable via config.json)
- Recompute trust automatically on admin approve/reject actions
- Manual trust override: admin can trust/untrust users manually,
  protected from automatic recomputation via `trust_manually_set` flag;
  "Reset to Auto" clears the flag and recomputes immediately
- Rejection reason support: admin can provide an optional reason on
  reject, shown to uploaders as a tooltip on image/game teasers
- New admin Approvals view: streamlined queue of public pending images
  with large previews
- New admin Uploaders view: per-user stats, trust toggle, manual flag
  indicator, expandable image previews, and bulk "Recompute Trust" tool
- Add admin endpoints: trust/untrust/reset-trust user, get uploaders,
  pending images, recompute trust for all uploaders
