### PR TITLE
fix: prevent password reset dialog from being closed on initial navigation

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -89,7 +89,11 @@ const run = async () => {
   })
 
   router.beforeEach((to, from) => {
-    closeDialog()
+    // Skip closing dialog on initial navigation (from.name is undefined)
+    // to avoid closing dialogs opened during app mount (e.g. password reset)
+    if (from.name) {
+      closeDialog()
+    }
 
     if (to.meta && to.meta.admin && !isAdmin.value) {
       return { name: 'index' }


### PR DESCRIPTION
`router.beforeEach` unconditionally called `closeDialog()` on every navigation, including the initial route resolution. Since the initial beforeEach fires after App.vue's onMounted (which opens the password reset dialog from the URL hash fragment), the dialog was immediately closed before the user could interact with it.

Skip `closeDialog()` when `from.name` is falsy (initial navigation) so that dialogs opened during app mount are preserved.
