### PR TITLE
improve and add more features to curation feature.

### DIFF
--- a/common/src/Types.ts
+++ b/common/src/Types.ts
@@ -908,6 +908,7 @@ export interface ImageRow {
 export interface ImageXTagRow {
   image_id: ImageId
   category_id: TagId
+  confirmed: boolean
 }
 
 export interface TagRow {
@@ -923,6 +924,15 @@ export interface TagRowWithCount extends TagRow {
 export interface ImageRowWithCount extends ImageRow {
   games_count: number
   uploader_user_name: string
+}
+
+export interface CurationEventRow {
+  id: number
+  image_id: ImageId
+  user_id: UserId
+  topic: string
+  decision: 'yes' | 'no'
+  created_at: string
 }
 
 export interface UploaderInfo {

--- a/common/src/TypesAdminApi.ts
+++ b/common/src/TypesAdminApi.ts
@@ -1,4 +1,4 @@
-import type { Announcement, FeaturedRow, FeaturedRowWithCollections, FeaturedTeaserRow, FixPiecesResult, GameRowWithImageAndUser, ImageInfo, ImageRowWithCount, MergeClientIdsIntoUserResult, Pagination, UploaderInfo, UserGroupRow, UserRow } from './Types'
+import type { Announcement, FeaturedRow, FeaturedRowWithCollections, FeaturedTeaserRow, FixPiecesResult, GameRowWithImageAndUser, ImageInfo, ImageRowWithCount, MergeClientIdsIntoUserResult, Pagination, TagRow, UploaderInfo, UserGroupRow, UserRow } from './Types'
 
 export type ErrorResponseData = {
   error: string
@@ -55,7 +55,7 @@ export type SetImageNsfwResponseData = AcknowledgeResponseData | ErrorResponseDa
 export type CurateImageResponseData = AcknowledgeResponseData | ErrorResponseData
 
 export type GetCurationQueueResponseData = {
-  image: ImageRowWithCount | null
+  image: (ImageRowWithCount & { tags: TagRow[], topic_value: string | number | boolean | null }) | null
   progress: { reviewed: number, total: number }
 } | ErrorResponseData
 

--- a/db/dbpatches/28_curation_events.sql
+++ b/db/dbpatches/28_curation_events.sql
@@ -1,0 +1,13 @@
+CREATE TABLE curation_events (
+  id SERIAL PRIMARY KEY,
+  image_id INTEGER NOT NULL REFERENCES images(id) ON DELETE CASCADE,
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  topic TEXT NOT NULL,
+  decision TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+CREATE INDEX idx_curation_events_image_topic ON curation_events(image_id, topic);
+CREATE INDEX idx_curation_events_topic ON curation_events(topic);
+
+ALTER TABLE image_x_category ADD COLUMN confirmed BOOLEAN DEFAULT FALSE;
+ALTER TABLE image_x_category ADD CONSTRAINT image_x_category_unique UNIQUE (image_id, category_id);

--- a/frontend/src/_api/admin.ts
+++ b/frontend/src/_api/admin.ts
@@ -8,7 +8,6 @@ import type {
   ServerInfo,
   UserId,
 } from '@common/Types'
-import type { ImageState } from '@common/Types'
 import xhr, { JSON_HEADERS } from './xhr'
 import Util from '@common/Util'
 
@@ -196,18 +195,20 @@ const rejectImage = async (
   return await res.json()
 }
 
-const getCurationQueue = async (): Promise<Api.Admin.GetCurationQueueResponseData> => {
-  const res = await xhr.get<Api.Admin.GetCurationQueueResponseData>('/admin/api/images/curation-queue')
+const getCurationQueue = async (topic: string, maxPasses: number): Promise<Api.Admin.GetCurationQueueResponseData> => {
+  const params = new URLSearchParams({ topic, maxPasses: String(maxPasses) })
+  const res = await xhr.get<Api.Admin.GetCurationQueueResponseData>(`/admin/api/images/curation-queue?${params}`)
   return await res.json()
 }
 
 const curateImage = async (
   id: ImageId,
-  value: ImageState.Curated | ImageState.Uncurated,
+  topic: string,
+  decision: 'yes' | 'no',
 ): Promise<Api.Admin.CurateImageResponseData> => {
   const res = await xhr.post<Api.Admin.CurateImageResponseData>(`/admin/api/images/${id}/_curate`, {
     headers: JSON_HEADERS,
-    body: JSON.stringify({ value }),
+    body: JSON.stringify({ topic, decision }),
   })
   return await res.json()
 }

--- a/frontend/src/admin/views/CurationView.vue
+++ b/frontend/src/admin/views/CurationView.vue
@@ -1,7 +1,42 @@
 <template>
   <div class="curation-fullscreen">
     <div class="curation-header">
-      <span class="text-body-2 text-disabled">Curation — {{ progress.reviewed }} / {{ progress.total }}</span>
+      <div class="curation-controls">
+        <v-select
+          v-model="topic"
+          :items="topicOptions"
+          item-title="label"
+          item-value="value"
+          density="compact"
+          variant="outlined"
+          hide-details
+          style="max-width: 180px"
+          @update:model-value="onTopicChange"
+        />
+        <v-text-field
+          v-if="topic === '_custom'"
+          v-model="customTag"
+          density="compact"
+          variant="outlined"
+          hide-details
+          placeholder="tag slug"
+          style="max-width: 140px"
+          @keydown.enter="onCustomTagConfirm"
+        />
+        <v-text-field
+          v-model.number="maxPasses"
+          type="number"
+          density="compact"
+          variant="outlined"
+          hide-details
+          label="Max passes"
+          min="0"
+          style="max-width: 100px"
+          @change="loadNext"
+        />
+        <span class="text-body-2 text-disabled">{{ progress.reviewed }} / {{ progress.total }}</span>
+        <span class="topic-label">{{ topicDisplay }}</span>
+      </div>
       <v-btn
         icon="mdi-close"
         size="small"
@@ -21,7 +56,7 @@
       v-else-if="!image"
       class="d-flex justify-center align-center flex-grow-1 text-h6"
     >
-      🎉 All images have been reviewed!
+      🎉 All done for this topic!
     </div>
 
     <template v-else>
@@ -49,68 +84,161 @@
             <span class="text-disabled">URL:</span>
             <span :class="{ 'text-warning': !image.copyright_url }">{{ image.copyright_url || '⚠ Missing' }}</span>
           </span>
-          <span><span class="text-disabled">{{ image.width }}×{{ image.height }}</span></span>
+          <span>
+            <span :class="imageSizeWarning ? 'text-warning' : 'text-disabled'">
+              {{ imageSizeWarning ? '⚠ ' : '' }}{{ image.width }}×{{ image.height }}
+            </span></span>
           <span><span class="text-disabled">State:</span> {{ image.state }}</span>
           <span v-if="image.nsfw">😳 NSFW</span>
           <span v-if="image.ai_generated">🤖 AI</span>
           <span><span class="text-disabled">Uploader:</span> {{ image.uploader_user_name || image.uploader_user_id || '-' }}</span>
           <span><span class="text-disabled">Games:</span> {{ image.games_count }}</span>
+          <span
+            v-if="image.tags.length"
+            class="curation-tags"
+          >
+            <v-chip
+              v-for="tag in image.tags"
+              :key="tag.id"
+              size="x-small"
+              variant="outlined"
+            >
+              {{ tag.title }}
+            </v-chip>
+          </span>
         </div>
         <div class="curation-actions">
+          <v-chip
+            :color="topicValueColor"
+            size="large"
+            variant="flat"
+            class="topic-value-chip"
+          >
+            {{ topicValueLabel }}
+          </v-chip>
           <v-btn
             color="success"
             size="large"
-            @click="onCurate(ImageState.Curated)"
+            @click="onCurate('yes')"
           >
             ✓ YES
           </v-btn>
           <v-btn
             color="warning"
             size="large"
-            @click="onCurate(ImageState.Uncurated)"
+            @click="onCurate('no')"
           >
             ✗ NO
           </v-btn>
-          <v-btn
-            color="error"
-            size="large"
-            @click="onDelete"
-          >
-            🗑 DELETE
-          </v-btn>
         </div>
+        <ImageActions
+          :image="image"
+          @updated="onImageUpdated"
+          @deleted="loadNext"
+        />
       </div>
     </template>
   </div>
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
-import { ImageState } from '@common/Types'
-import type { ImageRowWithCount } from '@common/Types'
+import { computed, onMounted, ref } from 'vue'
+import type { ImageRowWithCount, TagRow } from '@common/Types'
 import { resizeUrl } from '@common/ImageService'
 import api from '../../_api'
+import ImageActions from '../components/ImageActions.vue'
 
+type CurationImage = ImageRowWithCount & { tags: TagRow[], topic_value: string | number | boolean | null }
+
+const topicOptions = [
+  { label: 'Curated State', value: 'state' },
+  { label: 'AI Generated', value: 'ai_generated' },
+  { label: 'NSFW', value: 'nsfw' },
+  { label: 'Custom Tag…', value: '_custom' },
+]
+
+const topic = ref('state')
+const customTag = ref('')
+const maxPasses = ref(0)
 const loading = ref(true)
-const image = ref<ImageRowWithCount | null>(null)
+const image = ref<CurationImage | null>(null)
 const progress = ref({ reviewed: 0, total: 0 })
 
+const effectiveTopic = computed(() => {
+  if (topic.value === '_custom' && customTag.value) {
+    return `tag:${customTag.value}`
+  }
+  return topic.value === '_custom' ? '' : topic.value
+})
+
+const imageSizeWarning = computed(() => {
+  if (!image.value) return false
+  return image.value.width < 1000 || image.value.height < 1000
+})
+
+const topicDisplay = computed(() => {
+  const t = effectiveTopic.value
+  if (t === 'state') return 'Curating for: State'
+  if (t === 'ai_generated') return 'Curating for: AI Generated'
+  if (t === 'nsfw') return 'Curating for: NSFW'
+  if (t.startsWith('tag:')) return `Curating for: TAG "${t.slice(4)}"`
+  return ''
+})
+
+const topicValueColor = computed(() => {
+  const v = image.value?.topic_value
+  if (v === null || v === undefined) return 'grey'
+  const t = effectiveTopic.value
+  if (t === 'state') {
+    if (v === 'curated') return 'success'
+    if (v === 'uncurated') return 'warning'
+    return 'grey'
+  }
+  // boolean/number topics
+  return v ? 'success' : 'grey'
+})
+
+const topicValueLabel = computed(() => {
+  const v = image.value?.topic_value
+  if (v === null || v === undefined) return 'unset'
+  const t = effectiveTopic.value
+  if (t === 'state') return String(v)
+  if (t.startsWith('tag:')) return v ? 'tagged' : 'not tagged'
+  return v ? 'yes' : 'no'
+})
+
 const loadNext = async () => {
+  const t = effectiveTopic.value
+  if (!t) return
   loading.value = true
-  const resp = await api.admin.getCurationQueue()
+  const resp = await api.admin.getCurationQueue(t, maxPasses.value)
   if ('error' in resp) {
     alert('Failed to load curation queue')
     loading.value = false
     return
   }
-  image.value = resp.image
+  image.value = resp.image as CurationImage | null
   progress.value = resp.progress
   loading.value = false
 }
 
-const onCurate = async (value: ImageState.Curated | ImageState.Uncurated) => {
+const onTopicChange = () => {
+  if (topic.value !== '_custom') {
+    void loadNext()
+  }
+}
+
+const onCustomTagConfirm = () => {
+  if (customTag.value) {
+    void loadNext()
+  }
+}
+
+const onCurate = async (decision: 'yes' | 'no') => {
   if (!image.value) return
-  const resp = await api.admin.curateImage(image.value.id, value)
+  const t = effectiveTopic.value
+  if (!t) return
+  const resp = await api.admin.curateImage(image.value.id, t, decision)
   if ('error' in resp || !resp.ok) {
     alert('Curation failed!')
     return
@@ -118,15 +246,10 @@ const onCurate = async (value: ImageState.Curated | ImageState.Uncurated) => {
   await loadNext()
 }
 
-const onDelete = async () => {
-  if (!image.value) return
-  if (!confirm(`Really delete image ${image.value.id}?`)) return
-  const resp = await api.admin.deleteImage(image.value.id)
-  if ('error' in resp || !resp.ok) {
-    alert('Deleting image failed!')
-    return
+const onImageUpdated = (patch: Partial<ImageRowWithCount>) => {
+  if (image.value) {
+    Object.assign(image.value, patch)
   }
-  await loadNext()
 }
 
 onMounted(loadNext)
@@ -146,6 +269,22 @@ onMounted(loadNext)
   align-items: center;
   justify-content: space-between;
   padding: 4px 12px;
+  gap: 8px;
+}
+.curation-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.topic-label {
+  font-weight: 600;
+  font-size: 14px;
+  white-space: nowrap;
+}
+.topic-value-chip {
+  font-size: 16px;
+  font-weight: 600;
 }
 .curation-preview {
   flex: 1;
@@ -177,6 +316,12 @@ onMounted(loadNext)
   gap: 12px;
   flex-wrap: wrap;
   font-size: 15px;
+  align-items: center;
+}
+.curation-tags {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
 }
 .curation-actions {
   display: flex;

--- a/server/src/Images.test.ts
+++ b/server/src/Images.test.ts
@@ -192,3 +192,140 @@ describe('ImagesRepo.searchImagesWithCount - SQL filtering', () => {
     expect(result).toEqual([])
   })
 })
+
+describe('Images.setTags', () => {
+  let images: Images
+  let mockImagesRepo: any
+
+  beforeEach(() => {
+    mockImagesRepo = {
+      deleteTagRelations: vi.fn(),
+      upsertTag: vi.fn().mockImplementation(({ slug }: { slug: string }) => {
+        const map: Record<string, number> = { nature: 1, photo: 2, art: 3 }
+        return Promise.resolve((map[slug] ?? 99) as TagId)
+      }),
+      insertTagRelationIfNotExists: vi.fn(),
+    }
+    images = new Images(mockImagesRepo as unknown as ImagesRepo, {} as ImageExif)
+  })
+
+  it('calls deleteTagRelations with adminMode=false by default', async () => {
+    await images.setTags(10 as ImageId, ['nature'])
+    expect(mockImagesRepo.deleteTagRelations).toHaveBeenCalledWith(10, false)
+  })
+
+  it('calls deleteTagRelations with adminMode=true when specified', async () => {
+    await images.setTags(10 as ImageId, ['nature'], true)
+    expect(mockImagesRepo.deleteTagRelations).toHaveBeenCalledWith(10, true)
+  })
+
+  it('inserts tags via insertTagRelationIfNotExists', async () => {
+    await images.setTags(10 as ImageId, ['nature', 'photo'])
+    expect(mockImagesRepo.insertTagRelationIfNotExists).toHaveBeenCalledTimes(2)
+    expect(mockImagesRepo.insertTagRelationIfNotExists).toHaveBeenCalledWith(10, 1)
+    expect(mockImagesRepo.insertTagRelationIfNotExists).toHaveBeenCalledWith(10, 2)
+  })
+
+  it('skips tag if upsertTag returns falsy', async () => {
+    mockImagesRepo.upsertTag.mockResolvedValue(0)
+    await images.setTags(10 as ImageId, ['anything'])
+    expect(mockImagesRepo.insertTagRelationIfNotExists).not.toHaveBeenCalled()
+  })
+})
+
+describe('ImagesRepo.deleteTagRelations', () => {
+  it('deletes all tags in admin mode', async () => {
+    const mockDb = {
+      delete: vi.fn(),
+      run: vi.fn(),
+    }
+    const { ImagesRepo } = await import('./repo/ImagesRepo')
+    const repo = new ImagesRepo(mockDb as any)
+
+    await repo.deleteTagRelations(5 as ImageId, true)
+    expect(mockDb.delete).toHaveBeenCalledWith('image_x_category', { image_id: 5 })
+    expect(mockDb.run).not.toHaveBeenCalled()
+  })
+
+  it('only deletes unconfirmed tags in user mode', async () => {
+    const mockDb = {
+      delete: vi.fn(),
+      run: vi.fn(),
+    }
+    const { ImagesRepo } = await import('./repo/ImagesRepo')
+    const repo = new ImagesRepo(mockDb as any)
+
+    await repo.deleteTagRelations(5 as ImageId, false)
+    expect(mockDb.delete).not.toHaveBeenCalled()
+    expect(mockDb.run).toHaveBeenCalledWith(
+      expect.stringContaining('confirmed = false'),
+      [5],
+    )
+  })
+})
+
+describe('ImagesRepo.insertCurationEvent', () => {
+  it('inserts a curation event row', async () => {
+    const mockDb = {
+      insert: vi.fn(),
+    }
+    const { ImagesRepo } = await import('./repo/ImagesRepo')
+    const repo = new ImagesRepo(mockDb as any)
+
+    await repo.insertCurationEvent({
+      image_id: 42 as ImageId,
+      user_id: 1 as UserId,
+      topic: 'nsfw',
+      decision: 'yes',
+    })
+
+    expect(mockDb.insert).toHaveBeenCalledWith('curation_events', {
+      image_id: 42,
+      user_id: 1,
+      topic: 'nsfw',
+      decision: 'yes',
+    })
+  })
+})
+
+describe('ImagesRepo.getNextForCuration', () => {
+  it('passes topic and maxPasses to the query', async () => {
+    const mockDb = {
+      _get: vi.fn().mockResolvedValue(null),
+      _getMany: vi.fn().mockResolvedValue([]),
+      _buildWhere: vi.fn().mockReturnValue({ sql: 'WHERE 1=1', values: [] }),
+    }
+    const { ImagesRepo } = await import('./repo/ImagesRepo')
+    const repo = new ImagesRepo(mockDb as any)
+
+    const result = await repo.getNextForCuration('ai_generated', 2)
+
+    // First _get call is for stats
+    expect(mockDb._get.mock.calls[0][1]).toContain(2) // maxPasses
+    expect(mockDb._get.mock.calls[0][1]).toContain('ai_generated') // topic
+    expect(result.image).toBeNull()
+    expect(result.progress).toEqual({ reviewed: 0, total: 0 })
+  })
+
+  it('returns image with tags and topic_value when found', async () => {
+    const imageRow = createMockRow({ id: 7 as ImageId, ai_generated: 1 })
+    const mockDb = {
+      _get: vi.fn()
+        .mockResolvedValueOnce({ reviewed: 3, total: 10 }) // stats
+        .mockResolvedValueOnce(imageRow) // image
+        .mockResolvedValueOnce(null), // getTopicValue tag lookup (won't be called for ai_generated)
+      _getMany: vi.fn().mockResolvedValue([]), // getTagsByImageIds
+      _buildWhere: vi.fn().mockReturnValue({ sql: 'WHERE 1=1', values: [] }),
+    }
+    const { ImagesRepo } = await import('./repo/ImagesRepo')
+    const repo = new ImagesRepo(mockDb as any)
+
+    const result = await repo.getNextForCuration('ai_generated', 0)
+
+    expect(result.progress).toEqual({ reviewed: 3, total: 10 })
+    expect(result.image).not.toBeNull()
+    expect(result.image!.id).toBe(7)
+    expect(result.image!.topic_value).toBe(1) // ai_generated value
+    expect(result.image!.tags).toEqual([])
+  })
+})

--- a/server/src/Images.ts
+++ b/server/src/Images.ts
@@ -107,16 +107,14 @@ export class Images {
     return { w, h }
   }
 
-  public async setTags(imageId: ImageId, tags: string[]): Promise<void> {
-    await this.imagesRepo.deleteTagRelations(imageId)
+  public async setTags(imageId: ImageId, tags: string[], adminMode = false): Promise<void> {
+    await this.imagesRepo.deleteTagRelations(imageId, adminMode)
     for (const tag of tags) {
       const slug = Util.slug(tag)
       const id = await this.imagesRepo.upsertTag({ slug, title: tag })
       if (id) {
-        await this.imagesRepo.insertTagRelation({
-          image_id: imageId,
-          category_id: id,
-        })
+        // Use ON CONFLICT to avoid errors when a confirmed tag already exists
+        await this.imagesRepo.insertTagRelationIfNotExists(imageId, id)
       }
     }
   }

--- a/server/src/app/DbData.ts
+++ b/server/src/app/DbData.ts
@@ -20,6 +20,7 @@ export default {
     UserIdentity: 'user_identity',
     Users: 'users',
     UserSettings: 'user_settings',
+    CurationEvents: 'curation_events',
     UserXGame: 'user_x_game',
     UserXUserGroup: 'user_x_user_group',
   },

--- a/server/src/repo/ImagesRepo.ts
+++ b/server/src/repo/ImagesRepo.ts
@@ -1,5 +1,5 @@
 import { ImageSearchSort, ImageState, IMAGE_STATES_VISIBLE, IMAGE_STATES_PENDING, IMAGE_STATES_TRUSTED } from '@common/Types'
-import type { ImageId, ImageRow, ImageRowWithCount, ImageXTagRow, Pagination, TagId, TagRow, TagRowWithCount, UploaderInfo, UserId } from '@common/Types'
+import type { CurationEventRow, ImageId, ImageRow, ImageRowWithCount, Pagination, TagId, TagRow, TagRowWithCount, UploaderInfo, UserId } from '@common/Types'
 import type Db from '../lib/Db'
 import type { OrderBy, WhereRaw } from '../lib/Db'
 import DbData from '../app/DbData'
@@ -125,18 +125,27 @@ export class ImagesRepo {
     return { items, total }
   }
 
-  async getNextForCuration(): Promise<{ image: ImageRowWithCount | null, progress: { reviewed: number, total: number } }> {
-    const reviewedStates = this.db._buildWhere({ state: { '$in': [ImageState.Curated, ImageState.Uncurated] } })
+  async getNextForCuration(topic: string, maxPasses: number): Promise<{
+    image: (ImageRowWithCount & { tags: TagRow[], topic_value: string | number | boolean | null }) | null,
+    progress: { reviewed: number, total: number },
+  }> {
+    // Count total non-private images and how many have been reviewed (> maxPasses events for this topic)
     const statsRow = await this.db._get<{ reviewed: number, total: number }>(`
       SELECT
-        COUNT(*) FILTER (${reviewedStates.sql})::int AS reviewed,
+        COUNT(*) FILTER (WHERE ce_counts.cnt > $1)::int AS reviewed,
         COUNT(*)::int AS total
-      FROM ${DbData.Tables.Images}
-      WHERE private = 0
-    `, reviewedStates.values)
+      FROM ${DbData.Tables.Images} i
+      LEFT JOIN (
+        SELECT image_id, COUNT(*)::int AS cnt
+        FROM ${DbData.Tables.CurationEvents}
+        WHERE topic = $2
+        GROUP BY image_id
+      ) ce_counts ON ce_counts.image_id = i.id
+      WHERE i.private = 0
+    `, [maxPasses, topic])
     const progress = { reviewed: statsRow?.reviewed ?? 0, total: statsRow?.total ?? 0 }
 
-    const notReviewedWhere = this.db._buildWhere({ 'i.state': { '$nin': [ImageState.Curated, ImageState.Uncurated] } })
+    // Get next image with <= maxPasses events for this topic
     const image = await this.db._get<ImageRowWithCount>(`
       WITH counts AS (
         SELECT COUNT(*)::int AS count, image_id
@@ -150,19 +159,52 @@ export class ImagesRepo {
       FROM ${DbData.Tables.Images} i
         LEFT JOIN counts ON counts.image_id = i.id
         LEFT JOIN ${DbData.Tables.Users} u ON u.id = i.uploader_user_id
-      WHERE i.private = 0 AND ${notReviewedWhere.sql.replace('WHERE ', '')}
-      ORDER BY
-        CASE i.state
-          WHEN '${ImageState.Unreviewed}' THEN 0
-          WHEN '${ImageState.PendingApproval}' THEN 1
-          WHEN '${ImageState.Approved}' THEN 2
-          WHEN '${ImageState.Rejected}' THEN 3
-        END,
-        i.created ASC
+        LEFT JOIN (
+          SELECT image_id, COUNT(*)::int AS cnt
+          FROM ${DbData.Tables.CurationEvents}
+          WHERE topic = $1
+          GROUP BY image_id
+        ) ce_counts ON ce_counts.image_id = i.id
+      WHERE i.private = 0 AND COALESCE(ce_counts.cnt, 0) <= $2
+      ORDER BY i.created ASC
       LIMIT 1
-    `, notReviewedWhere.values)
+    `, [topic, maxPasses])
 
-    return { image: image ?? null, progress }
+    if (!image) {
+      return { image: null, progress }
+    }
+
+    // Get tags for this image
+    const tags = await this.getTagsByImageIds([image.id])
+    const imageTags = tags[image.id] ?? []
+
+    // Compute the current topic value
+    const topicValue = await this.getTopicValue(image, topic)
+
+    return {
+      image: { ...image, tags: imageTags, topic_value: topicValue },
+      progress,
+    }
+  }
+
+  private async getTopicValue(
+    image: ImageRow,
+    topic: string,
+  ): Promise<string | number | boolean | null> {
+    if (topic === 'state') return image.state
+    if (topic === 'ai_generated') return image.ai_generated
+    if (topic === 'nsfw') return image.nsfw
+    if (topic.startsWith('tag:')) {
+      const slug = topic.slice(4)
+      const row = await this.db._get<{ confirmed: boolean }>(`
+        SELECT ixc.confirmed
+        FROM ${DbData.Tables.ImageXTag} ixc
+        INNER JOIN ${DbData.Tables.Tags} t ON t.id = ixc.category_id
+        WHERE ixc.image_id = $1 AND t.slug = $2
+      `, [image.id, slug])
+      return row ? true : false
+    }
+    return null
   }
 
   async insert(image: Omit<ImageRow, 'id'>): Promise<ImageId> {
@@ -173,12 +215,47 @@ export class ImagesRepo {
     await this.db.update(DbData.Tables.Images, image, where)
   }
 
-  async deleteTagRelations(imageId: ImageId): Promise<void> {
-    await this.db.delete(DbData.Tables.ImageXTag, { image_id: imageId })
+  async insertCurationEvent(event: Omit<CurationEventRow, 'id' | 'created_at'>): Promise<void> {
+    await this.db.insert(DbData.Tables.CurationEvents, event)
   }
 
-  async insertTagRelation(imageXtag: ImageXTagRow): Promise<void> {
-    await this.db.insert(DbData.Tables.ImageXTag, imageXtag)
+  async deleteTagRelations(imageId: ImageId, adminMode = false): Promise<void> {
+    if (adminMode) {
+      await this.db.delete(DbData.Tables.ImageXTag, { image_id: imageId })
+    } else {
+      await this.db.run(
+        `DELETE FROM ${DbData.Tables.ImageXTag} WHERE image_id = $1 AND confirmed = false`,
+        [imageId],
+      )
+    }
+  }
+
+  async upsertConfirmedTag(imageId: ImageId, tagSlug: string): Promise<void> {
+    const tag = await this.upsertTag({ slug: tagSlug, title: tagSlug })
+    if (!tag) return
+    // upsert: insert or update confirmed = true
+    await this.db.run(`
+      INSERT INTO ${DbData.Tables.ImageXTag} (image_id, category_id, confirmed)
+      VALUES ($1, $2, true)
+      ON CONFLICT (image_id, category_id) DO UPDATE SET confirmed = true
+    `, [imageId, tag])
+  }
+
+  async removeTag(imageId: ImageId, tagSlug: string): Promise<void> {
+    const tags = await this.getTagsBySlugs([tagSlug])
+    if (!tags.length) return
+    await this.db.run(
+      `DELETE FROM ${DbData.Tables.ImageXTag} WHERE image_id = $1 AND category_id = $2`,
+      [imageId, tags[0].id],
+    )
+  }
+
+  async insertTagRelationIfNotExists(imageId: ImageId, tagId: TagId): Promise<void> {
+    await this.db.run(`
+      INSERT INTO ${DbData.Tables.ImageXTag} (image_id, category_id, confirmed)
+      VALUES ($1, $2, false)
+      ON CONFLICT (image_id, category_id) DO NOTHING
+    `, [imageId, tagId])
   }
 
   async upsertTag(tag: Omit<TagRow, 'id'>): Promise<TagId> {

--- a/server/src/web_routes/admin/api/index.ts
+++ b/server/src/web_routes/admin/api/index.ts
@@ -217,12 +217,17 @@ export default function createRouter(
 
   router.delete('/images/:id', async (req, res) => {
     const id = parseInt(req.params.id, 10) as ImageId
+    const userId = req.userInfo!.user!.id
     const image = await server.repos.images.get({ id })
     if (!image) {
       const responseData: Api.Admin.DeleteImageResponseData = { error: 'image does not exist' }
       res.status(404).send(responseData)
       return
     }
+
+    await server.repos.images.insertCurationEvent({
+      image_id: id, user_id: userId, topic: 'delete', decision: 'yes',
+    })
 
     // delete from db
     await server.repos.images.delete(id)
@@ -240,6 +245,7 @@ export default function createRouter(
   router.post('/images/:id/_set_private', express.json(), async (req, res) => {
     try {
       const id = parseInt(req.params.id, 10) as ImageId
+      const userId = req.userInfo!.user!.id
       const image = await server.repos.images.get({ id })
       if (!image) {
         const responseData: Api.Admin.SetImagePrivateResponseData = { error: 'image does not exist' }
@@ -252,6 +258,10 @@ export default function createRouter(
         { private: value },
         { id },
       )
+
+      await server.repos.images.insertCurationEvent({
+        image_id: id, user_id: userId, topic: 'private', decision: value ? 'yes' : 'no',
+      })
 
       // set games currently in play to private, so they dont overwrite the db value when persisting
       const gameIds = await server.repos.games.getIds({ image_id: id })
@@ -284,6 +294,7 @@ export default function createRouter(
   router.post('/images/:id/_approve', async (req, res) => {
     try {
       const id = parseInt(req.params.id, 10) as ImageId
+      const userId = req.userInfo!.user!.id
       const image = await server.repos.images.get({ id })
       if (!image) {
         const responseData: Api.Admin.ApproveImageResponseData = { error: 'image does not exist' }
@@ -295,6 +306,10 @@ export default function createRouter(
         { state: ImageState.Approved },
         { id },
       )
+
+      await server.repos.images.insertCurationEvent({
+        image_id: id, user_id: userId, topic: 'state', decision: 'yes',
+      })
 
       const threshold = config.trust?.threshold ?? 5
       await server.repos.users.recomputeTrust(image.uploader_user_id, threshold)
@@ -309,6 +324,7 @@ export default function createRouter(
   router.post('/images/:id/_reject', express.json(), async (req, res) => {
     try {
       const id = parseInt(req.params.id, 10) as ImageId
+      const userId = req.userInfo!.user!.id
       const image = await server.repos.images.get({ id })
       if (!image) {
         const responseData: Api.Admin.RejectImageResponseData = { error: 'image does not exist' }
@@ -322,6 +338,10 @@ export default function createRouter(
         { id },
       )
 
+      await server.repos.images.insertCurationEvent({
+        image_id: id, user_id: userId, topic: 'state', decision: 'no',
+      })
+
       const threshold = config.trust?.threshold ?? 5
       await server.repos.users.recomputeTrust(image.uploader_user_id, threshold)
 
@@ -332,9 +352,11 @@ export default function createRouter(
     }
   })
 
-  router.get('/images/curation-queue', async (_req, res) => {
+  router.get('/images/curation-queue', async (req, res) => {
     try {
-      const result = await server.repos.images.getNextForCuration()
+      const topic = (req.query.topic as string) || 'state'
+      const maxPasses = parseInt(req.query.maxPasses as string, 10) || 0
+      const result = await server.repos.images.getNextForCuration(topic, maxPasses)
       const responseData: Api.Admin.GetCurationQueueResponseData = result
       res.send(responseData)
     } catch (error) {
@@ -345,6 +367,7 @@ export default function createRouter(
   router.post('/images/:id/_curate', express.json(), async (req, res) => {
     try {
       const id = parseInt(req.params.id, 10) as ImageId
+      const userId = req.userInfo!.user!.id
       const image = await server.repos.images.get({ id })
       if (!image) {
         const responseData: Api.Admin.CurateImageResponseData = { error: 'image does not exist' }
@@ -352,20 +375,43 @@ export default function createRouter(
         return
       }
 
-      const value = req.body?.value
-      if (value !== ImageState.Curated && value !== ImageState.Uncurated) {
-        const responseData: Api.Admin.CurateImageResponseData = { error: 'value must be "curated" or "uncurated"' }
+      const { topic, decision } = req.body
+      if (decision !== 'yes' && decision !== 'no') {
+        const responseData: Api.Admin.CurateImageResponseData = { error: 'decision must be "yes" or "no"' }
         res.status(400).send(responseData)
         return
       }
 
-      await server.repos.images.update(
-        { state: value },
-        { id },
-      )
+      // Apply the decision
+      if (topic === 'state') {
+        const value = decision === 'yes' ? ImageState.Curated : ImageState.Uncurated
+        await server.repos.images.update({ state: value }, { id })
+        const threshold = config.trust?.threshold ?? 5
+        await server.repos.users.recomputeTrust(image.uploader_user_id, threshold)
+      } else if (topic === 'ai_generated') {
+        await server.repos.images.update({ ai_generated: decision === 'yes' ? 1 : 0 }, { id })
+      } else if (topic === 'nsfw') {
+        await server.repos.images.update({ nsfw: decision === 'yes' ? 1 : 0 }, { id })
+      } else if (topic.startsWith('tag:')) {
+        const slug = topic.slice(4)
+        if (decision === 'yes') {
+          await server.repos.images.upsertConfirmedTag(id, slug)
+        } else {
+          await server.repos.images.removeTag(id, slug)
+        }
+      } else {
+        const responseData: Api.Admin.CurateImageResponseData = { error: 'unknown topic' }
+        res.status(400).send(responseData)
+        return
+      }
 
-      const threshold = config.trust?.threshold ?? 5
-      await server.repos.users.recomputeTrust(image.uploader_user_id, threshold)
+      // Log curation event
+      await server.repos.images.insertCurationEvent({
+        image_id: id,
+        user_id: userId,
+        topic,
+        decision,
+      })
 
       const responseData: Api.Admin.CurateImageResponseData = { ok: true }
       res.send(responseData)
@@ -377,6 +423,7 @@ export default function createRouter(
   router.post('/images/:id/_set_ai_generated', express.json(), async (req, res) => {
     try {
       const id = parseInt(req.params.id, 10) as ImageId
+      const userId = req.userInfo!.user!.id
       const image = await server.repos.images.get({ id })
       if (!image) {
         const responseData: Api.Admin.SetImageAiGeneratedResponseData = { error: 'image does not exist' }
@@ -390,6 +437,10 @@ export default function createRouter(
         { id },
       )
 
+      await server.repos.images.insertCurationEvent({
+        image_id: id, user_id: userId, topic: 'ai_generated', decision: value ? 'yes' : 'no',
+      })
+
       const responseData: Api.Admin.SetImageAiGeneratedResponseData = { ok: true }
       res.send(responseData)
     } catch (error) {
@@ -400,6 +451,7 @@ export default function createRouter(
   router.post('/images/:id/_set_nsfw', express.json(), async (req, res) => {
     try {
       const id = parseInt(req.params.id, 10) as ImageId
+      const userId = req.userInfo!.user!.id
       const image = await server.repos.images.get({ id })
       if (!image) {
         const responseData: Api.Admin.SetImageNsfwResponseData = { error: 'image does not exist' }
@@ -412,6 +464,10 @@ export default function createRouter(
         { nsfw: value },
         { id },
       )
+
+      await server.repos.images.insertCurationEvent({
+        image_id: id, user_id: userId, topic: 'nsfw', decision: value ? 'yes' : 'no',
+      })
 
       const responseData: Api.Admin.SetImageNsfwResponseData = { ok: true }
       res.send(responseData)


### PR DESCRIPTION
- curation events are tracked now so we can do multiple passes
- allows curation on user base
- allows curation for topics (ai generated/nsfw/state/specific tags)
- admin-tags are now "fixed" and cant be removed by users (same as that they cannot unset nsfw/ai_generated)
